### PR TITLE
bug fix for firstLevelTransitive calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+1.9.11 / 2014-06-05
+===================
+
+* Fix first level transitive calculation, makes sure project dependencies do not have locked versions
+
 1.9.10 / 2014-06-04
 ===================
 

--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
@@ -80,8 +80,10 @@ class GenerateLockTask extends AbstractLockTask {
         sibling.children.each { ResolvedDependency dependency ->
             def key = new LockKey(group: dependency.moduleGroup, artifact: dependency.moduleName)
             deps[key].firstLevelTransitive << parent
-            if (peers.contains(key) && !deps[key].childrenVisited) {
-                if (dependency.children.size() > 0) {
+            
+            if (peers.contains(key)) {
+                deps[key].project = true
+                if ((dependency.children.size() > 0) && !deps[key].childrenVisited) {
                     deps[key].childrenVisited = true
                     handleSiblingTransitives(dependency, deps, peers)
                 }


### PR DESCRIPTION
Deep nesting of compile project(':sub1') depends on compile project(':sub2') was leading to those interproject dependencies being locked to specific versions.
