### PR TITLE
fixed value of `group` property for lock tasks

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/AbstractLockTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/AbstractLockTask.groovy
@@ -18,5 +18,5 @@ package nebula.plugin.dependencylock.tasks
 import org.gradle.api.DefaultTask
 
 abstract class AbstractLockTask extends DefaultTask {
-    String group = 'Locking tasks'
+    String group = 'Locking'
 }


### PR DESCRIPTION
- `gradle tasks` will now print "Locking tasks" instead of "Locking tasks tasks"
