### PR TITLE
Improve performance of enforcing locks by pre-parsing dependencies

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockPlugin.groovy
@@ -316,7 +316,7 @@ class DependencyLockPlugin implements Plugin<Project> {
         // Pretty nice after all that work (:
         project.configurations.all {
             resolutionStrategy {
-                lockForces.each { dep -> force dep }
+                force lockForces.toArray()
             }
         }
     }

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockPlugin.groovy
@@ -307,13 +307,16 @@ class DependencyLockPlugin implements Plugin<Project> {
 
         // If the user specifies an override that does not exist in the lock file, force that dependency anyway.
         def unusedOverrides = overrides.findAll { !locks.containsKey(it.key) }.collect { "${it.key}:${it.value}" }
-        lockForces << unusedOverrides
-        logger.debug(lockForces.toString())
+        lockForces.addAll(unusedOverrides)
+        logger.debug('lockForces: {}', lockForces)
+
+        // Create the dependencies explicitly to avoid doing that implicitly for every configuration
+        lockForces = lockForces.collect { dep -> project.dependencies.create(dep) }
 
         // Pretty nice after all that work (:
         project.configurations.all {
             resolutionStrategy {
-                lockForces.each { dep -> force dep}
+                lockForces.each { dep -> force dep }
             }
         }
     }


### PR DESCRIPTION
Gradle's notation parsing is expensive, because it checks for a plain Dependency first, rather than a string notation, and it uses exceptions for flow control.

This parses the dependencies up front, avoiding parsing the dependencies for each configuration, and calls `force` once with all dependencies to avoid the parser init overhead. It also changes a debug statement to make the `toString` lazy, rather than calling it eagerly.