### PR TITLE
Fix forcing dependencies on creating a global lock

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockPlugin.groovy
@@ -246,6 +246,7 @@ class DependencyLockPlugin implements Plugin<Project> {
                 def subprojects = project.subprojects.collect { project.dependencies.create(it) }
                 def subprojectsArray = subprojects.toArray(new Dependency[subprojects.size()])
                 def conf = project.configurations.detachedConfiguration(subprojectsArray)
+                project.allprojects.each { it.configurations.add(conf) }
 
                 [conf]
             }


### PR DESCRIPTION
The global lock support currently ignores all resolution strategy forces. This fixes that by adding the generated detached configuration to each project, triggering any configured resolution strategies on that configuration.