### PR TITLE
Fix missing quote from example build file

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ The lock will have
 
     dependencies {
       compile 'com.google.guava:guava:14.+'
-      testCompile 'junit:junit:4.+
+      testCompile 'junit:junit:4.+'
     }
 
 When you run


### PR DESCRIPTION
Tiny fix but it caught me out when trying out the example code. That said, perhaps for the optimal learning experience, I should have re-typed it instead of cut & paste ;-)