### PR TITLE
Use chosen subproject configs in global lock

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockPlugin.groovy
@@ -243,7 +243,16 @@ class DependencyLockPlugin implements Plugin<Project> {
                 new File(project.buildDir, globalLockFileName ?: extension.globalLockFile)
             }
             configurations = {
-                def subprojects = project.subprojects.collect { project.dependencies.create(it) }
+                def subprojects = project.subprojects.collect { subproject ->
+                    def ext = subproject.getExtensions().findByType(DependencyLockExtension)
+                    if (ext != null) {
+                        ext.configurationNames.collect { subconf ->
+                            project.dependencies.create(project.dependencies.project(path: subproject.path, configuration: subconf))
+                        }
+                    } else {
+                        [project.dependencies.create(subproject)]
+                    }
+                }.flatten()
                 def subprojectsArray = subprojects.toArray(new Dependency[subprojects.size()])
                 def conf = project.configurations.detachedConfiguration(subprojectsArray)
                 project.allprojects.each { it.configurations.add(conf) }

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
@@ -460,6 +460,46 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
         new File(projectDir, 'build/global.lock').text == globalLockText
     }
 
+    def 'uses chosen subproject configurations when creating global lock in multiproject'() {
+        addSubproject('sub1', """\
+            configurations {
+                special
+            }
+            dependencies {
+                compile 'test.example:bar:1.1.0'
+                special 'test.example:foo:2.0.0'
+            }
+            dependencyLock.configurationNames = ['testRuntime', 'special']
+        """.stripIndent())
+
+        buildFile << """\
+            allprojects {
+                ${applyPlugin(DependencyLockPlugin)}
+                group = 'test'
+            }
+            subprojects {
+                apply plugin: 'java'
+                repositories { maven { url '${Fixture.repo}' } }
+            }
+            dependencyLock {
+                includeTransitives = true
+            }
+        """.stripIndent()
+
+        when:
+        runTasksSuccessfully('generateGlobalLock')
+
+        then:
+        String globalLockText = '''\
+            {
+              "test.example:bar": { "locked": "1.1.0", "transitive": [ "test:sub1" ] },
+              "test.example:foo": { "locked": "2.0.0", "transitive": [ "test.example:bar", "test:sub1" ] },
+              "test:sub1": { "project": true }
+            }
+        '''.stripIndent()
+        new File(projectDir, 'build/global.lock').text == globalLockText
+    }
+
     def 'save global lock in multiproject'() {
         setupCommonMultiproject()
 


### PR DESCRIPTION
If you go through the trouble of configuring which configurations should be locked on a per-project basis, I'd expect the global lock to use those same configs. This change makes that happen.