### PR TITLE
Follow-up to PR-64 with more accurate option name & description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ Allows the user to specify a String for the tagname. If present commitLock will 
 By default this option is true meaning that the locking will be applied in an `afterEvaluate` block. In certain circumstances
 it can be advantageous to apply the lock outside of an `afterEvaluate` block; for example projects that explicitly trigger 
 dependency configuration resolution via the `resolvedConfiguration()` method prior to when the lock would normally be 
-applied in an `afterEvaluate` block.
+applied in an `afterEvaluate` block. Thus, to lock outside of an `afterEvaluate` block, set the `lockAfterEvaluating`
+project property to false as follows:
 
     ./gradlew -PdependencyLock.lockAfterEvaluating=false <tasks>
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The following values are the defaults. If they work for you, you can skip config
       updateDependencies = []
       skippedDependencies = []
       includeTransitives = false
-      lockAtConfigurationPhase = false
+      lockAfterEvaluating = true
     }
 
 #### commitDependencyLock Extension
@@ -193,13 +193,14 @@ Allows the user to specify a String for the tagname. If present commitLock will 
 
     ./gradlew -PcommitDependencyLock.tag=mytag <tasks> commitLock
     
-*dependencyLock.lockAtConfigurationPhase*
+*dependencyLock.lockAfterEvaluating*
 
-Allows the user to apply the lock to the dependency configuration prior to the task execution phase. Using terminology
-from the [Gradle build lifecycle documentation](https://docs.gradle.org/current/userguide/build_lifecycle.html) the
-locking is applied at *Configuration* phase rather than *Execution* phase.
+By default this option is true meaning that the locking will be applied in a `afterEvaluate` block. In certain circumstances
+it can be advantageous to apply the lock outside of an `afterEvaluate` block; for example this can happen for projects
+that explicitly trigger dependency configuration resolution via the `resolvedConfiguration()` prior to when the lock would normally
+be applied in an `afterEvaluate` block.
 
-    ./gradlew -PdependencyLock.lockAtConfigurationPhase=true <tasks>
+    ./gradlew -PdependencyLock.lockAfterEvaluating=false <tasks>
 
 ## Lock File Format
 

--- a/README.md
+++ b/README.md
@@ -195,10 +195,10 @@ Allows the user to specify a String for the tagname. If present commitLock will 
     
 *dependencyLock.lockAfterEvaluating*
 
-By default this option is true meaning that the locking will be applied in a `afterEvaluate` block. In certain circumstances
-it can be advantageous to apply the lock outside of an `afterEvaluate` block; for example this can happen for projects
-that explicitly trigger dependency configuration resolution via the `resolvedConfiguration()` prior to when the lock would normally
-be applied in an `afterEvaluate` block.
+By default this option is true meaning that the locking will be applied in an `afterEvaluate` block. In certain circumstances
+it can be advantageous to apply the lock outside of an `afterEvaluate` block; for example projects that explicitly trigger 
+dependency configuration resolution via the `resolvedConfiguration()` method prior to when the lock would normally be 
+applied in an `afterEvaluate` block.
 
     ./gradlew -PdependencyLock.lockAfterEvaluating=false <tasks>
 

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
@@ -23,5 +23,5 @@ class DependencyLockExtension {
     Set<String> updateDependencies = [] as Set
     Set<String> skippedDependencies = [] as Set
     boolean includeTransitives = false
-    boolean lockAtConfigurationPhase = false
+    boolean lockAfterEvaluating = true
 }

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockPlugin.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockPlugin.groovy
@@ -108,13 +108,13 @@ class DependencyLockPlugin implements Plugin<Project> {
             }
         }
 
-        def lockAtConfigurationPhase = project.hasProperty('dependencyLock.lockAtConfigurationPhase') ? Boolean.parseBoolean(project['dependencyLock.lockAtConfigurationPhase']) : extension.lockAtConfigurationPhase
-        if (lockAtConfigurationPhase) {
-            logger.info("Applying dependency lock at the configuration phase")
-            applyLockToResolutionStrategy()
-        } else {
-            logger.info("Applying dependency lock at the execution phase")
+        def lockAfterEvaluating = project.hasProperty('dependencyLock.lockAfterEvaluating') ? Boolean.parseBoolean(project['dependencyLock.lockAfterEvaluating']) : extension.lockAfterEvaluating
+        if (lockAfterEvaluating) {
+            logger.info("Applying dependency lock in afterEvaluate block")
             project.afterEvaluate applyLockToResolutionStrategy
+        } else {
+            logger.info("Applying dependency lock as is (outside afterEvaluate block)")
+            applyLockToResolutionStrategy()
         }
 
         project.gradle.taskGraph.whenReady { taskGraph ->

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginSpec.groovy
@@ -51,7 +51,7 @@ class DependencyLockPluginSpec extends ProjectSpec {
     }
 
     // Same as 'read in dependencies.lock' except we don't call triggerAfterEvaluate
-    def 'read in dependencies.lock at outside afterEvaluate block'() {
+    def 'read in dependencies.lock outside an afterEvaluate block'() {
         stockTestSetup()
         project.ext.set('dependencyLock.lockAfterEvaluating', "false")
 

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginSpec.groovy
@@ -51,9 +51,9 @@ class DependencyLockPluginSpec extends ProjectSpec {
     }
 
     // Same as 'read in dependencies.lock' except we don't call triggerAfterEvaluate
-    def 'read in dependencies.lock at configuration time'() {
+    def 'read in dependencies.lock at outside afterEvaluate block'() {
         stockTestSetup()
-        project.ext.set('dependencyLock.lockAtConfigurationPhase', "true")
+        project.ext.set('dependencyLock.lockAfterEvaluating', "false")
 
         when:
         project.apply plugin: pluginName


### PR DESCRIPTION
This PR is a follow up to [PR 64](https://github.com/nebula-plugins/gradle-dependency-lock-plugin/pull/64) with a more accurate description and aptly named project property. This PR will hopefully be clearer and not cause confusion by implying that `afterEvaluate` blocks happen at the execution phase.

This does invert the option parameter - default is true and override is false. In any event the default preserves the prior behaviour of the dependency lock plugin.