### PR TITLE
switch to jackson objectmapper instead of jsonslurper

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockReader.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockReader.groovy
@@ -1,5 +1,6 @@
 package nebula.plugin.dependencylock
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import groovy.json.JsonSlurper
 import groovy.transform.TupleConstructor
 import org.gradle.api.GradleException
@@ -13,6 +14,7 @@ import static DependencyLockTaskConfigurer.GLOBAL_LOCK_CONFIG
 @TupleConstructor
 class DependencyLockReader {
     private static final Logger logger = Logging.getLogger(DependencyLockReader)
+    private static final ObjectMapper mapper = new ObjectMapper()
 
     Project project
 
@@ -82,7 +84,7 @@ class DependencyLockReader {
 
     private static Map parseLockFile(File lock) {
         try {
-            return new JsonSlurper().parseText(lock.text) as Map
+            return mapper.readValue(lock.text, HashMap)
         } catch (ex) {
             logger.debug('Unreadable json file: ' + lock.text)
             logger.error('JSON unreadable')

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginSpec.groovy
@@ -360,7 +360,7 @@ class DependencyLockPluginSpec extends ProjectSpec {
                     },
                     "test.example:foo": {
                         "locked": "2.0.0",
-                        "requested": "2.+",
+                        "requested": "2.+"
                     },
                     "test.nebula:sub1": {
                         "project": true,


### PR DESCRIPTION
Found some issues while trying to use this plugin in resolutions-rules one related to Groovy's JsonSlurper

```
java.lang.NoClassDefFoundError: Could not initialize class org.apache.groovy.json.internal.FastStringUtils$ServiceHolder
```