### PR TITLE
Migrate to core lock format

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
@@ -15,7 +15,7 @@
  */
 package nebula.plugin.dependencylock.tasks
 
-
+import nebula.plugin.dependencylock.DependencyLockExtension
 import nebula.plugin.dependencylock.DependencyLockReader
 import nebula.plugin.dependencylock.DependencyLockTaskConfigurer
 import nebula.plugin.dependencylock.DependencyLockWriter
@@ -46,6 +46,12 @@ class GenerateLockTask extends AbstractLockTask {
     @TaskAction
     void lock() {
         if (CoreLocking.isCoreLockingEnabled()) {
+            def dependencyLockExtension = project.extensions.findByType(DependencyLockExtension)
+            def globalLockFile = new File(project.projectDir, dependencyLockExtension.globalLockFile)
+            if (globalLockFile.exists()) {
+                throw new BuildCancelledException("Legacy global locks are not supported with core locking.\nPlease remove ${globalLockFile.absolutePath}")
+            }
+
             throw new BuildCancelledException("generateLock is not supported with core locking. Please use `./gradlew dependencies --write-locks`")
         }
         if (DependencyLockTaskConfigurer.shouldIgnoreDependencyLock(project)) {

--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
@@ -15,6 +15,7 @@
  */
 package nebula.plugin.dependencylock.tasks
 
+
 import nebula.plugin.dependencylock.DependencyLockReader
 import nebula.plugin.dependencylock.DependencyLockTaskConfigurer
 import nebula.plugin.dependencylock.DependencyLockWriter

--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/UpdateLockTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/UpdateLockTask.groovy
@@ -15,6 +15,7 @@
  */
 package nebula.plugin.dependencylock.tasks
 
+import nebula.plugin.dependencylock.DependencyLockExtension
 import nebula.plugin.dependencylock.utils.CoreLocking
 import org.gradle.api.BuildCancelledException
 import org.gradle.api.tasks.TaskAction
@@ -30,6 +31,12 @@ class UpdateLockTask extends GenerateLockTask {
     @Override
     void lock() {
         if (CoreLocking.isCoreLockingEnabled()) {
+            def dependencyLockExtension = project.extensions.findByType(DependencyLockExtension)
+            def globalLockFile = new File(project.projectDir, dependencyLockExtension.globalLockFile)
+            if (globalLockFile.exists()) {
+                throw new BuildCancelledException("Legacy global locks are not supported with core locking.\nPlease remove ${globalLockFile.absolutePath}")
+            }
+
             throw new BuildCancelledException("updateLock is not supported with core locking. Please use `./gradlew dependencies --update-locks group1:module1,group2:module2`")
         }
         super.lock()

--- a/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
+++ b/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
@@ -85,16 +85,21 @@ class DependencyLockPlugin : Plugin<Project> {
                     try {
                         FileUtils.delete(lockFile)
                     } catch (e: Exception) {
-                        throw BuildCancelledException("Failed to delete legacy locks. Please remove ${lockFile.absolutePath} manually.", e)
+                        throw BuildCancelledException("Failed to delete legacy locks.\nPlease remove ${lockFile.absolutePath} manually.", e)
                     }
                 } else {
-                    throw BuildCancelledException("Legacy locks are not supported with core locking. Please remove ${lockFile.absolutePath}\n" +
+                    throw BuildCancelledException("Legacy locks are not supported with core locking.\nPlease remove ${lockFile.absolutePath}\n" +
                             "If you wish to migrate with the current locked dependencies, please use `./gradlew dependencies --write-locks`")
                 }
             }
+
+            val taskNames = project.gradle.startParameter.taskNames
+            val hasUpdateTask = hasUpdateTask(taskNames)
+            val hasGenerationTask = hasGenerationTask(taskNames)
             val globalLockFile = File(project.projectDir, extension.globalLockFile)
-            if (globalLockFile.exists()) {
-                throw BuildCancelledException("Legacy global locks are not supported with core locking. Please remove ${globalLockFile.absolutePath}")
+
+            if (globalLockFile.exists() && !hasGenerationTask && !hasUpdateTask) {
+                throw BuildCancelledException("Legacy global locks are not supported with core locking.\nPlease remove ${globalLockFile.absolutePath}")
             }
 
         } else {

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
@@ -58,7 +58,7 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
         """.stripIndent()
     }
 
-    def 'core lock file is being generated'() {
+    def 'generate core lock file'() {
         when:
         def result = runTasks('dependencies', '--write-locks')
 
@@ -70,21 +70,6 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
         def lockFile = new File(projectDir, '/gradle/dependency-locks/compile.lockfile').text
         lockFile.contains('test.nebula:a:1.0.0')
         lockFile.contains('test.nebula:b:1.1.0')
-    }
-
-    def 'fail with core lock if legacy lock is present and not writing locks'() {
-        given:
-        def legacyLockFile = new File(projectDir, 'dependencies.lock')
-        legacyLockFile.text = expectedNebulaLockText
-
-        when:
-        def result = runTasksAndFail('dependencies')
-
-        then:
-        result.output.contains("Legacy locks are not supported with core locking")
-        result.output.contains("If you wish to migrate with the current locked dependencies")
-        assertFailureOccursAtPluginLevel(result.output)
-        legacyLockFile.exists()
     }
 
     def 'migrate to core lock when legacy lock is present and writing locks'() {
@@ -143,7 +128,7 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'fail at task level with core lock if legacy global lock is present when running #task'() {
+    def 'fail if legacy global lock is present with core lock when running #task with error at task level'() {
         given:
         buildFile.text = """\
             plugins {
@@ -167,7 +152,7 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
     }
 
     @Unroll
-    def 'fail at plugin level with core lock if legacy global lock is present when running #taskGroup'() {
+    def 'fail if legacy global lock is present with core lock when running #taskGroup with error at plugin level'() {
         given:
         buildFile.text = """\
             plugins {
@@ -176,7 +161,8 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
             }
             """
 
-        new File(projectDir, 'global.lock').text = """{}"""
+        def legacyGlobalLockFile = new File(projectDir, 'global.lock')
+        legacyGlobalLockFile.text = """{}"""
 
         when:
         def result = runTasksAndFail(*tasks)
@@ -184,6 +170,7 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
         then:
         result.output.contains("Legacy global locks are not supported with core locking")
         assertFailureOccursAtPluginLevel(result.output)
+        legacyGlobalLockFile.exists()
 
         where:
         taskGroup                    | tasks
@@ -191,7 +178,22 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
         'clean build'                | ['clean', 'build']
     }
 
-    def 'fail with core lock if if you try to use legacy generateLock'() {
+    def 'fail if legacy lock is present with core lock and not writing locks with error at plugin level'() {
+        given:
+        def legacyLockFile = new File(projectDir, 'dependencies.lock')
+        legacyLockFile.text = expectedNebulaLockText
+
+        when:
+        def result = runTasksAndFail('dependencies')
+
+        then:
+        result.output.contains("Legacy locks are not supported with core locking")
+        result.output.contains("If you wish to migrate with the current locked dependencies")
+        assertFailureOccursAtPluginLevel(result.output)
+        legacyLockFile.exists()
+    }
+
+    def 'fail if legacy lock is present with core lock when running generateLock with error at task level'() {
         given:
         buildFile.text = """\
             plugins {
@@ -206,10 +208,11 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
         then:
         result.output.contains("generateLock is not supported with core locking")
         result.output.contains("Please use `./gradlew dependencies --write-locks`")
+        result.output.contains("> Task :generateLock FAILED")
         assertNoErrorsOnAParticularBuildLine(result.output)
     }
 
-    def 'fail with core lock if if you try to use legacy updateLock'() {
+    def 'fail if legacy lock is present with core lock when running updateLock with error at task level'() {
         given:
         buildFile.text = """\
             plugins {
@@ -224,6 +227,7 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
         then:
         result.output.contains("updateLock is not supported with core locking")
         result.output.contains("Please use `./gradlew dependencies --update-locks group1:module1,group2:module2`")
+        result.output.contains("> Task :updateLock FAILED")
         assertNoErrorsOnAParticularBuildLine(result.output)
     }
 

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
@@ -1,22 +1,36 @@
 package nebula.plugin.dependencylock
 
+import nebula.plugin.dependencylock.util.LockGenerator
 import nebula.test.IntegrationTestKitSpec
 import nebula.test.dependencies.DependencyGraphBuilder
 import nebula.test.dependencies.GradleDependencyGenerator
 
 class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
+    def expectedLocks = [
+            'compile.lockfile', 'archives.lockfile', 'testCompileClasspath.lockfile', 'compileOnly.lockfile',
+            'annotationProcessor.lockfile', 'runtime.lockfile', 'compileClasspath.lockfile', 'testCompile.lockfile',
+            'default.lockfile', 'testAnnotationProcessor.lockfile', 'testRuntime.lockfile',
+            'testRuntimeClasspath.lockfile', 'testCompileOnly.lockfile', 'runtimeClasspath.lockfile'
+    ] as String[]
+    def expectedNebulaLockText = LockGenerator.duplicateIntoConfigs(
+            '''\
+                "test.nebula:a": {
+                    "locked": "1.0.0",
+                    "requested": "1.0.0"
+                },
+                "test.nebula:b": {
+                    "locked": "1.1.0",
+                    "requested": "1.1.0"
+                }'''.stripIndent())
 
     def setup() {
-        debug = true
+        keepFiles = true
         new File("${projectDir}/gradle.properties").text = "systemProp.nebula.features.coreLockingSupport=true"
 
         settingsFile << '''\
             rootProject.name = 'locktest'
         '''.stripIndent()
-    }
 
-    def 'core lock file is being generated'() {
-        given:
         def graph = new DependencyGraphBuilder()
                 .addModule('test.nebula:a:1.0.0')
                 .addModule('test.nebula:a:1.1.0')
@@ -40,49 +54,95 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
                 compile 'test.nebula:a:1.0.0'
                 compile 'test.nebula:b:1.1.0'
             }
-
         """.stripIndent()
+    }
 
+    def 'core lock file is being generated'() {
         when:
         def result = runTasks('dependencies', '--write-locks')
 
         then:
         result.output.contains('coreLockingSupport feature enabled')
         def actualLocks = new File(projectDir, '/gradle/dependency-locks/').list().toList()
-        def expectedLocks = [
-                'compile.lockfile', 'archives.lockfile', 'testCompileClasspath.lockfile', 'compileOnly.lockfile',
-                'annotationProcessor.lockfile', 'runtime.lockfile', 'compileClasspath.lockfile', 'testCompile.lockfile',
-                'default.lockfile', 'testAnnotationProcessor.lockfile', 'testRuntime.lockfile',
-                'testRuntimeClasspath.lockfile', 'testCompileOnly.lockfile', 'runtimeClasspath.lockfile'
-        ] as String[]
+
         actualLocks.containsAll(expectedLocks)
         def lockFile = new File(projectDir, '/gradle/dependency-locks/compile.lockfile').text
         lockFile.contains('test.nebula:a:1.0.0')
         lockFile.contains('test.nebula:b:1.1.0')
     }
 
-    def 'fail with core lock if legacy lock is present'() {
+    def 'fail with core lock if legacy lock is present and not writing locks'() {
         given:
-        buildFile << """\
-            plugins {
-                id 'nebula.dependency-lock'
-                id 'java'
-            }
-            """
-
-        new File(projectDir, 'dependencies.lock').text = """{}"""
+        def legacyLockFile = new File(projectDir, 'dependencies.lock')
+        legacyLockFile.text = expectedNebulaLockText
 
         when:
-        def result = runTasksAndFail('dependencies', '--write-locks')
+        def result = runTasksAndFail('dependencies')
 
         then:
         result.output.contains("Legacy locks are not supported with core locking")
+        result.output.contains("If you wish to migrate with the current locked dependencies")
+        legacyLockFile.exists()
+    }
 
+    def 'migrates to core lock when legacy lock is present and writing locks'() {
+        given:
+        def legacyLockFile = new File(projectDir, 'dependencies.lock')
+        legacyLockFile.text = expectedNebulaLockText
+
+        when:
+        def result = runTasks('dependencies', '--write-locks')
+
+        then:
+        !result.output.contains('not supported')
+        result.output.contains('Migrating legacy locks')
+        def actualLocks = new File(projectDir, '/gradle/dependency-locks/').list().toList()
+
+        actualLocks.containsAll(expectedLocks)
+        def lockFile = new File(projectDir, '/gradle/dependency-locks/compile.lockfile').text
+        lockFile.contains('test.nebula:a:1.0.0')
+        lockFile.contains('test.nebula:b:1.1.0')
+
+        !legacyLockFile.exists()
+    }
+
+    def 'migrates to core lock when legacy lock is present and writing locks with custom task'() {
+        given:
+        buildFile << '''
+            task resolveAndLockAll {
+                doFirst {
+                    assert gradle.startParameter.writeDependencyLocks
+                }
+                doLast {
+                    configurations.findAll {
+                        // Add any custom filtering on the configurations to be resolved
+                        it.canBeResolved
+                    }.each { it.resolve() }
+                }
+            }'''.stripIndent()
+
+        def legacyLockFile = new File(projectDir, 'dependencies.lock')
+        legacyLockFile.text = expectedNebulaLockText
+
+        when:
+        def result = runTasks('resolveAndLockAll', '--write-locks')
+
+        then:
+        !result.output.contains('not supported')
+        result.output.contains('Migrating legacy locks')
+        def actualLocks = new File(projectDir, '/gradle/dependency-locks/').list().toList()
+
+        actualLocks.containsAll(expectedLocks)
+        def lockFile = new File(projectDir, '/gradle/dependency-locks/compile.lockfile').text
+        lockFile.contains('test.nebula:a:1.0.0')
+        lockFile.contains('test.nebula:b:1.1.0')
+
+        !legacyLockFile.exists()
     }
 
     def 'fail with core lock if legacy global lock is present'() {
         given:
-        buildFile << """\
+        buildFile.text = """\
             plugins {
                 id 'nebula.dependency-lock'
                 id 'java'
@@ -101,7 +161,7 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
 
     def 'fail with core lock if if you try to use legacy generateLock'() {
         given:
-        buildFile << """\
+        buildFile.text = """\
             plugins {
                 id 'nebula.dependency-lock'
                 id 'java'
@@ -113,12 +173,12 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
 
         then:
         result.output.contains("generateLock is not supported with core locking")
-
+        result.output.contains("Please use `./gradlew dependencies --write-locks`")
     }
 
     def 'fail with core lock if if you try to use legacy updateLock'() {
         given:
-        buildFile << """\
+        buildFile.text = """\
             plugins {
                 id 'nebula.dependency-lock'
                 id 'java'
@@ -130,7 +190,7 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
 
         then:
         result.output.contains("updateLock is not supported with core locking")
-
+        result.output.contains("Please use `./gradlew dependencies --update-locks group1:module1,group2:module2`")
     }
 
 }


### PR DESCRIPTION
### If you have been using project locks

If you have been using tasks such as `generateLock`, `saveLock`, and `updateLock`, then you can run

```
./gradlew dependencies --write-locks
```

or other tasks to resolve all project configurations (such as those needed for a multi-project build)

and you will be migrated to [core Gradle locks](https://docs.gradle.org/current/userguide/dependency_locking.html).

### If you have been using global locks

These are not supported by core Gradle locks. You will need to delete the global lock and use project locks.
