### PR TITLE
Task migrateToCoreLocks locks previously unlocked dependencies

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/AbstractMigrateToCoreLocksTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/AbstractMigrateToCoreLocksTask.groovy
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2014-2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package nebula.plugin.dependencylock.tasks
+
+import nebula.plugin.dependencylock.ConfigurationsToLockFinder
+import org.gradle.api.DefaultTask
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.execution.TaskExecutionGraph
+import org.gradle.api.tasks.OutputDirectory
+
+abstract class AbstractMigrateToCoreLocksTask extends DefaultTask {
+    String group = 'Locking'
+
+    @OutputDirectory
+    File outputLocksDirectory
+
+    Set<String> configurationNames
+
+    void lockSelectedConfigurations() {
+        project.gradle.taskGraph.whenReady { TaskExecutionGraph taskGraph ->
+            if (project.hasProperty("lockAllConfigurations") && (project.property("lockAllConfigurations") as String).toBoolean()) {
+                project.dependencyLocking {
+                    it.lockAllConfigurations()
+                }
+            } else {
+                def configurationsToLock = new ConfigurationsToLockFinder(project)
+                        .findConfigurationsToLock(getConfigurationNames())
+                project.configurations.each {
+                    if (configurationsToLock.contains(it.name)) {
+                        it.resolutionStrategy.activateDependencyLocking()
+                    }
+                }
+            }
+        }
+    }
+
+    Collection<Configuration> lockableConfigurations() {
+        GenerateLockTask.lockableConfigurations(project, project, getConfigurationNames())
+    }
+}

--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/MigrateLockedDepsToCoreLocksTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/MigrateLockedDepsToCoreLocksTask.groovy
@@ -1,0 +1,110 @@
+/**
+ *
+ *  Copyright 2014-2019 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package nebula.plugin.dependencylock.tasks
+
+import nebula.plugin.dependencylock.DependencyLockReader
+import nebula.plugin.dependencylock.utils.CoreLocking
+import org.gradle.api.BuildCancelledException
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+
+class MigrateLockedDepsToCoreLocksTask extends AbstractMigrateToCoreLocksTask {
+    String description = "Migrates Nebula-locked dependencies to use core Gradle locks"
+    private static final Logger LOGGER = Logging.getLogger(MigrateLockedDepsToCoreLocksTask)
+
+    @InputFile
+    File inputLockFile
+
+    @TaskAction
+    void migrateLockedDependencies() {
+        if (CoreLocking.isCoreLockingEnabled()) {
+            lockSelectedConfigurations()
+
+            if (getInputLockFile().exists()) {
+                LOGGER.warn("Migrating legacy locks to core Gradle locking. This will remove legacy locks.\n" +
+                        " - Legacy lock: ${getInputLockFile().absolutePath}\n" +
+                        " - Core Gradle locks: ${getOutputLocksDirectory().absoluteFile}")
+                if (!getOutputLocksDirectory().exists()) {
+                    createOutputLocksDirectory()
+                }
+
+                def lockReader = new DependencyLockReader(project)
+
+                lockableConfigurations().forEach { conf ->
+                    def dependenciesForConf = new ArrayList()
+                    def locks = lockReader.readLocks(conf, getInputLockFile())
+
+                    if (locks != null) {
+                        for (Map.Entry<String, ArrayList<String>> entry : locks.entrySet()) {
+                            def groupAndName = entry.key as String
+                            def entryLockedValue = (entry.value as Map<String, String>)["locked"]
+                            if (entryLockedValue != null) {
+                                def lockedVersion = entryLockedValue as String
+                                dependenciesForConf.add("$groupAndName:$lockedVersion")
+                            } else {
+                                LOGGER.info("No locked version for '$groupAndName' to migrate in $conf")
+                            }
+                        }
+                    }
+
+                    def configLockFile = new File(getOutputLocksDirectory(), "/${conf.name}.lockfile")
+                    if (!configLockFile.exists()) {
+                        configLockFile.createNewFile()
+                        configLockFile.write("# This is a file for dependency locking, migrated from Nebula locks.\n" +
+                                "# Manual edits can break the build and are not advised.\n" +
+                                "# This file is expected to be part of source control.\n")
+
+                        dependenciesForConf.sort()
+
+                        configLockFile.append(dependenciesForConf.join('\n'))
+                    }
+                }
+
+                deleteInputLockFile()
+            }
+        }
+    }
+
+    private void deleteInputLockFile() {
+        def failureToDeleteInputLockFileMessage = "Failed to delete legacy locks.\n" +
+                "Please remove the legacy lockfile manually.\n" +
+                " - Legacy lock: ${getInputLockFile().absolutePath}"
+        try {
+            if (!getInputLockFile().delete()) {
+                throw new BuildCancelledException(failureToDeleteInputLockFileMessage)
+            }
+        } catch (Exception e) {
+            throw new BuildCancelledException(failureToDeleteInputLockFileMessage, e)
+        }
+    }
+
+    private void createOutputLocksDirectory() {
+        def failureToDeleteOutputLocksDirectoryMessage = "Failed to create core lock directory. Check your permissions.\n" +
+                " - Core lock directory: ${getOutputLocksDirectory().absolutePath}"
+        try {
+            if (!getOutputLocksDirectory().mkdirs()) {
+                throw new BuildCancelledException(failureToDeleteOutputLocksDirectoryMessage)
+            }
+        } catch (Exception e) {
+            throw new BuildCancelledException(failureToDeleteOutputLocksDirectoryMessage, e)
+        }
+    }
+}


### PR DESCRIPTION
When you run `migrateToCoreLocks`, two tasks are actually run. 

- The first migrates all the locked dependencies from `dependencies.lock` into the core Gradle lock format
- The second finds any dependencies that had not been locked (due to not being added to lock state or not locking transitive dependencies) and locks them in the core Gradle lock format