### PR TITLE
Core locking: slim down the configurations to lock by default

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
@@ -31,28 +31,22 @@ class ConfigurationsToLockFinder {
         this.project = project
     }
 
-    List<String> findConfigurationsToLock(Set<String> configurationNames) {
+    List<String> findConfigurationsToLock(Set<String> configurationNames, List<String> additionalBaseConfigurationsToLock = new ArrayList<>()) {
         def configurationsToLock = new ArrayList<String>()
         def baseConfigurations = [
                 'annotationProcessor',
-                'apiElements',
-                'archives',
-                'compile',
                 'compileClasspath',
-                'compileOnly',
-                'default',
-                'implementation',
-                'runtime',
-                'runtimeClasspath',
-                'runtimeElements',
-                'runtimeOnly']
+                'runtimeClasspath'
+        ]
+        baseConfigurations.addAll(additionalBaseConfigurationsToLock)
+
         configurationsToLock.addAll(baseConfigurations)
 
-        def confSuffix = 'CompileOnly'
+        def confSuffix = 'CompileClasspath'
         def configurationsWithPrefix = project.configurations.findAll { it.name.contains(confSuffix) }
         configurationsWithPrefix.each {
             def confPrefix = it.name.replace(confSuffix, '')
-            configurationsToLock.addAll(returnConfigurationNamesWithPrefix(confPrefix))
+            configurationsToLock.addAll(returnConfigurationNamesWithPrefix(confPrefix, baseConfigurations))
         }
 
         // ensure gathered configurations to lock are lockable
@@ -68,17 +62,11 @@ class ConfigurationsToLockFinder {
         return lockableConfigsToLock.sort()
     }
 
-    private static List<String> returnConfigurationNamesWithPrefix(it) {
-        def testConfigurations = [
-                "${it}AnnotationProcessor".toString(),
-                "${it}Compile".toString(),
-                "${it}CompileClasspath".toString(),
-                "${it}CompileOnly".toString(),
-                "${it}Implementation".toString(),
-                "${it}Runtime".toString(),
-                "${it}RuntimeClasspath".toString(),
-                "${it}RuntimeOnly".toString()
-        ]
-        testConfigurations
+    private static List<String> returnConfigurationNamesWithPrefix(it, List<String> baseConfigurations) {
+        def configurationNamesWithPrefix = []
+        baseConfigurations.each { baseConfig ->
+            configurationNamesWithPrefix.add("${it}${baseConfig.capitalize()}".toString())
+        }
+        return configurationNamesWithPrefix
     }
 }

--- a/src/test/groovy/nebula/plugin/dependencylock/tasks/MigrateToCoreLocksTaskSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/tasks/MigrateToCoreLocksTaskSpec.groovy
@@ -9,10 +9,10 @@ import spock.lang.Unroll
 
 class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
     def expectedLocks = [
-            'compile.lockfile', 'archives.lockfile', 'testCompileClasspath.lockfile', 'compileOnly.lockfile',
-            'annotationProcessor.lockfile', 'runtime.lockfile', 'compileClasspath.lockfile', 'testCompile.lockfile',
-            'default.lockfile', 'testAnnotationProcessor.lockfile', 'testRuntime.lockfile',
-            'testRuntimeClasspath.lockfile', 'testCompileOnly.lockfile', 'runtimeClasspath.lockfile'
+            'annotationProcessor.lockfile',
+            'compileClasspath.lockfile',
+            'testAnnotationProcessor.lockfile',
+            'testRuntimeClasspath.lockfile'
     ] as String[]
     def mavenrepo
     def projectName
@@ -88,7 +88,7 @@ class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
         def actualLocks = new File(projectDir, '/gradle/dependency-locks/').list().toList()
 
         actualLocks.containsAll(expectedLocks)
-        def lockFile = new File(projectDir, '/gradle/dependency-locks/compile.lockfile')
+        def lockFile = new File(projectDir, '/gradle/dependency-locks/compileClasspath.lockfile')
         lockFile.text.contains('test.nebula:a:1.0.0')
         lockFile.text.contains('test.nebula:b:1.1.0')
 
@@ -196,7 +196,7 @@ class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
         def actualLocks = new File(projectDir, '/gradle/dependency-locks/').list().toList()
 
         actualLocks.containsAll(expectedLocks)
-        def lockFile = new File(projectDir, '/gradle/dependency-locks/compile.lockfile')
+        def lockFile = new File(projectDir, '/gradle/dependency-locks/compileClasspath.lockfile')
         lockFile.text.contains('test.nebula:a:1.0.0')
         lockFile.text.contains('test.nebula:b:1.1.0')
         lockFile.text.contains('test.nebula:c:1.0.0')
@@ -243,7 +243,7 @@ class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
         def actualLocks = new File(projectDir, '/gradle/dependency-locks/').list().toList()
 
         actualLocks.containsAll(expectedLocks)
-        def lockFile = new File(projectDir, '/gradle/dependency-locks/compile.lockfile')
+        def lockFile = new File(projectDir, '/gradle/dependency-locks/compileClasspath.lockfile')
         lockFile.text.contains('test.nebula:a:1.0.0')
         lockFile.text.contains('test.nebula:b:1.1.0')
         lockFile.text.contains('test.nebula:c:1.0.0')
@@ -323,13 +323,13 @@ class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
 
         def sub1ActualLocks = new File(projectDir, 'sub1/gradle/dependency-locks/').list().toList()
         sub1ActualLocks.containsAll(expectedLocks)
-        def sub1LockFile = new File(projectDir, 'sub1/gradle/dependency-locks/compile.lockfile')
+        def sub1LockFile = new File(projectDir, 'sub1/gradle/dependency-locks/compileClasspath.lockfile')
         sub1LockFile.text.contains('test.nebula:a:1.0.0')
         !sub1LegacyLockFile.exists()
 
         def sub2ActualLocks = new File(projectDir, 'sub2/gradle/dependency-locks/').list().toList()
         sub2ActualLocks.containsAll(expectedLocks)
-        def sub2LockFile = new File(projectDir, 'sub2/gradle/dependency-locks/compile.lockfile')
+        def sub2LockFile = new File(projectDir, 'sub2/gradle/dependency-locks/compileClasspath.lockfile')
         sub2LockFile.text.contains('test.nebula:c:1.0.0')
         sub2LockFile.text.contains('test.nebula:d:1.0.0')
         !sub2LegacyLockFile.exists()
@@ -407,17 +407,17 @@ class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
         then:
         !result.output.contains('not supported')
         result.output.contains('Migrating legacy locks')
-        result.output.contains("No locked version for '${projectName}:sub1' to migrate in configuration ':sub2:compile'")
+        result.output.contains("No locked version for '${projectName}:sub1' to migrate in configuration ':sub2:compileClasspath'")
 
         def sub1ActualLocks = new File(projectDir, 'sub1/gradle/dependency-locks/').list().toList()
         sub1ActualLocks.containsAll(expectedLocks)
-        def sub1LockFile = new File(projectDir, 'sub1/gradle/dependency-locks/compile.lockfile')
+        def sub1LockFile = new File(projectDir, 'sub1/gradle/dependency-locks/compileClasspath.lockfile')
         sub1LockFile.text.contains('test.nebula:a:1.0.0')
         !sub1LegacyLockFile.exists()
 
         def sub2ActualLocks = new File(projectDir, 'sub2/gradle/dependency-locks/').list().toList()
         sub2ActualLocks.containsAll(expectedLocks)
-        def sub2LockFile = new File(projectDir, 'sub2/gradle/dependency-locks/compile.lockfile')
+        def sub2LockFile = new File(projectDir, 'sub2/gradle/dependency-locks/compileClasspath.lockfile')
         sub2LockFile.text.contains('test.nebula:a:1.0.0')
         sub2LockFile.text.contains('test.nebula:c:1.0.0')
         sub2LockFile.text.contains('test.nebula:d:1.0.0')
@@ -501,13 +501,13 @@ class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
 
         def sub1ActualLocks = new File(projectDir, 'sub1/gradle/dependency-locks/').list().toList()
         sub1ActualLocks.containsAll(expectedLocks)
-        def sub1LockFile = new File(projectDir, 'sub1/gradle/dependency-locks/compile.lockfile')
+        def sub1LockFile = new File(projectDir, 'sub1/gradle/dependency-locks/compileClasspath.lockfile')
         sub1LockFile.text.contains('test.nebula:a:1.0.0')
         !sub1LegacyLockFile.exists()
 
         def sub2ActualLocks = new File(projectDir, 'sub2/gradle/dependency-locks/').list().toList()
         sub2ActualLocks.containsAll(expectedLocks)
-        def sub2LockFile = new File(projectDir, 'sub2/gradle/dependency-locks/compile.lockfile')
+        def sub2LockFile = new File(projectDir, 'sub2/gradle/dependency-locks/compileClasspath.lockfile')
         sub2LockFile.text.contains('test.nebula:a:1.0.0')
         sub2LockFile.text.findAll('test.nebula:a:1.0.0').size() == 1
         sub2LockFile.text.contains('test.nebula:c:1.0.0')
@@ -535,7 +535,7 @@ class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
         def actualLocks = new File(projectDir, '/gradle/dependency-locks/').list().toList()
 
         actualLocks.containsAll(expectedLocks)
-        def lockFile = new File(projectDir, '/gradle/dependency-locks/compile.lockfile')
+        def lockFile = new File(projectDir, '/gradle/dependency-locks/compileClasspath.lockfile')
         lockFile.text.contains('test.nebula:a:1.0.0')
         lockFile.text.contains('test.nebula:b:1.1.0')
     }
@@ -605,10 +605,7 @@ class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
 
         def facetLockfiles = [
                 "${facet}AnnotationProcessor.lockfile".toString(),
-                "${facet}Compile.lockfile".toString(),
                 "${facet}CompileClasspath.lockfile".toString(),
-                "${facet}CompileOnly.lockfile".toString(),
-                "${facet}Runtime.lockfile".toString(),
                 "${facet}RuntimeClasspath.lockfile".toString()
         ]
         def updatedExpectedLocks = expectedLocks + facetLockfiles
@@ -616,7 +613,7 @@ class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
             assert actualLocks.contains(it)
         }
 
-        def lockFile = new File(projectDir, "/gradle/dependency-locks/${facet}Compile.lockfile")
+        def lockFile = new File(projectDir, "/gradle/dependency-locks/${facet}compileClasspath.lockfile")
         lockFile.text.contains('test.nebula:a:1.0.0')
         lockFile.text.contains('junit:junit:4.12')
         lockFile.text.contains('org.hamcrest:hamcrest-core:1.3')
@@ -687,10 +684,7 @@ class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
 
         def facetLockfiles = [
                 "${facet}AnnotationProcessor.lockfile".toString(),
-                "${facet}Compile.lockfile".toString(),
                 "${facet}CompileClasspath.lockfile".toString(),
-                "${facet}CompileOnly.lockfile".toString(),
-                "${facet}Runtime.lockfile".toString(),
                 "${facet}RuntimeClasspath.lockfile".toString()
         ]
         def updatedExpectedLocks = expectedLocks + facetLockfiles
@@ -699,11 +693,11 @@ class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
         }
 
         // compile lock came from json lockfile
-        def compileLockFile = new File(projectDir, "/gradle/dependency-locks/compile.lockfile")
+        def compileLockFile = new File(projectDir, "/gradle/dependency-locks/compileClasspath.lockfile")
         compileLockFile.text.contains('test.nebula:a:1.0.0')
 
         // facet lock had been unlocked & resolved to different version
-        def facetLockFile = new File(projectDir, "/gradle/dependency-locks/${facet}Compile.lockfile")
+        def facetLockFile = new File(projectDir, "/gradle/dependency-locks/${facet}compileClasspath.lockfile")
         facetLockFile.text.contains('test.nebula:a:1.1.0')
 
         where:

--- a/src/test/groovy/nebula/plugin/dependencylock/tasks/MigrateToCoreLocksTaskSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/tasks/MigrateToCoreLocksTaskSpec.groovy
@@ -11,7 +11,9 @@ class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
     def expectedLocks = [
             'annotationProcessor.lockfile',
             'compileClasspath.lockfile',
+            'runtimeClasspath.lockfile',
             'testAnnotationProcessor.lockfile',
+            'testCompileClasspath.lockfile',
             'testRuntimeClasspath.lockfile'
     ] as String[]
     def mavenrepo
@@ -613,10 +615,10 @@ class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
             assert actualLocks.contains(it)
         }
 
-        def lockFile = new File(projectDir, "/gradle/dependency-locks/${facet}compileClasspath.lockfile")
-        lockFile.text.contains('test.nebula:a:1.0.0')
-        lockFile.text.contains('junit:junit:4.12')
-        lockFile.text.contains('org.hamcrest:hamcrest-core:1.3')
+        def lockFile = new File(projectDir, "/gradle/dependency-locks/${facet}CompileClasspath.lockfile")
+        assert lockFile.text.contains('test.nebula:a:1.0.0')
+        assert lockFile.text.contains('junit:junit:4.12')
+        assert lockFile.text.contains('org.hamcrest:hamcrest-core:1.3')
 
         where:
         facet       | plugin             | setParentSourceSet
@@ -697,8 +699,8 @@ class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
         compileLockFile.text.contains('test.nebula:a:1.0.0')
 
         // facet lock had been unlocked & resolved to different version
-        def facetLockFile = new File(projectDir, "/gradle/dependency-locks/${facet}compileClasspath.lockfile")
-        facetLockFile.text.contains('test.nebula:a:1.1.0')
+        def facetLockFile = new File(projectDir, "/gradle/dependency-locks/${facet}CompileClasspath.lockfile")
+        assert facetLockFile.text.contains('test.nebula:a:1.1.0')
 
         where:
         facet       | plugin             | setParentSourceSet


### PR DESCRIPTION
to allow versions for plugin configurations to float

Also added a test for a scala project. Scala incremental compilation configurations are non-resolvable and extend from `compile` (resolvable) and `implementation` (non-resolvable) rather than `compileClasspath`. Currently emitting a warning about dependencies listed as `implementation` rather than `compile`