### PR TITLE
Core locking update with examples for multiprojects & kotlin projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ dependencies {
     compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
 
     testCompile 'com.netflix.nebula:gradle-git-scm-plugin:latest.release'
+    testCompile 'com.netflix.nebula:nebula-test:latest.release'
     testImplementation gradleTestKit()
     testCompile ('org.ajoberstar.grgit:grgit-core:3.0.0-beta.1') {
         exclude group: 'org.codehaus.groovy', module: 'groovy'

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -171,8 +171,8 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
-            "requested": "7.+"
+            "locked": "7.2.5",
+            "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.8.0",
@@ -217,8 +217,8 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
-            "requested": "7.+"
+            "locked": "7.2.5",
+            "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.8.0",
@@ -263,8 +263,8 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
-            "requested": "7.+"
+            "locked": "7.2.5",
+            "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.8.0",
@@ -309,8 +309,8 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
-            "requested": "7.+"
+            "locked": "7.2.5",
+            "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.8.0",
@@ -355,8 +355,8 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
-            "requested": "7.+"
+            "locked": "7.2.5",
+            "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.8.0",
@@ -401,8 +401,8 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
-            "requested": "7.+"
+            "locked": "7.2.5",
+            "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.8.0",
@@ -427,12 +427,12 @@
     },
     "jacocoAgent": {
         "org.jacoco:org.jacoco.agent": {
-            "locked": "0.8.2"
+            "locked": "0.8.3"
         }
     },
     "jacocoAnt": {
         "org.jacoco:org.jacoco.ant": {
-            "locked": "0.8.2"
+            "locked": "0.8.3"
         }
     },
     "kotlinCompilerClasspath": {
@@ -528,8 +528,8 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
-            "requested": "7.+"
+            "locked": "7.2.5",
+            "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.8.0",
@@ -574,8 +574,8 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
-            "requested": "7.+"
+            "locked": "7.2.5",
+            "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.8.0",
@@ -620,8 +620,8 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
-            "requested": "7.+"
+            "locked": "7.2.5",
+            "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.8.0",
@@ -666,8 +666,8 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
-            "requested": "7.+"
+            "locked": "7.2.5",
+            "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.8.0",
@@ -712,8 +712,8 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
-            "requested": "7.+"
+            "locked": "7.2.5",
+            "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.8.0",
@@ -758,8 +758,8 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.1.7",
-            "requested": "7.+"
+            "locked": "7.2.5",
+            "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.8.0",

--- a/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
@@ -59,7 +59,21 @@ class ConfigurationsToLockFinder {
             lockableConfigurationNames.contains(it)
         }
 
-        return lockableConfigsToLock.sort()
+        def kotlinPlugins = project.plugins.findAll { it.class.name.contains("Kotlin") }
+        if (!lockableConfigsToLock.contains('compileClasspath')
+                || kotlinPlugins.size() > 0) {
+            def defaultConfigurations = project.configurations
+                    .findAll { it.name == 'default' }
+                    .each { it.isCanBeResolved() }
+            if (defaultConfigurations.size() > 0) {
+                defaultConfigurations.each {
+                    lockableConfigsToLock.add(it.name)
+                }
+            }
+        }
+
+        def sortedLockableConfigs = lockableConfigsToLock.sort()
+        return sortedLockableConfigs
     }
 
     private static List<String> returnConfigurationNamesWithPrefix(it, List<String> baseConfigurations) {


### PR DESCRIPTION
* lock 'default' configuration in kotlin projects
* add test case for multi-project core locking example