### PR TITLE
Core locks: lock configurations when java-based plugins are applied, …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,10 +41,15 @@ contacts {
     }
 }
 
+ext {
+    kotlinVersion = '1.3.11'
+}
+
 dependencies {
     compile 'com.squareup.moshi:moshi:1.8.0'
     compile 'joda-time:joda-time:2.10'
     compile 'com.netflix.nebula:nebula-gradle-interop:latest.release'
+    compile "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     compile 'com.netflix.nebula:gradle-scm-plugin:latest.release'
     compile 'com.netflix.nebula:gradle-metrics-plugin:8.+', optional
     compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'
@@ -52,7 +57,7 @@ dependencies {
     testCompile 'com.netflix.nebula:gradle-git-scm-plugin:latest.release'
     testCompile 'com.netflix.nebula:nebula-test:latest.release'
     testImplementation gradleTestKit()
-    testCompile ('org.ajoberstar.grgit:grgit-core:3.0.0-beta.1') {
+    testCompile('org.ajoberstar.grgit:grgit-core:3.0.0-beta.1') {
         exclude group: 'org.codehaus.groovy', module: 'groovy'
     }
 

--- a/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
@@ -59,19 +59,6 @@ class ConfigurationsToLockFinder {
             lockableConfigurationNames.contains(it)
         }
 
-        def kotlinPlugins = project.plugins.findAll { it.class.name.contains("Kotlin") }
-        if (!lockableConfigsToLock.contains('compileClasspath')
-                || kotlinPlugins.size() > 0) {
-            def defaultConfigurations = project.configurations
-                    .findAll { it.name == 'default' }
-                    .each { it.isCanBeResolved() }
-            if (defaultConfigurations.size() > 0) {
-                defaultConfigurations.each {
-                    lockableConfigsToLock.add(it.name)
-                }
-            }
-        }
-
         def sortedLockableConfigs = lockableConfigsToLock.sort()
         return sortedLockableConfigs
     }

--- a/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
@@ -24,6 +24,9 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.plugins.JavaLibraryPlugin
+import org.gradle.api.plugins.JavaPlugin
 
 class CoreLockingHelper {
     private Project project
@@ -68,6 +71,17 @@ class CoreLockingHelper {
         project.plugins.withId("nebula.integtest") {
             runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
         }
+        project.plugins.withType(JavaLibraryPlugin.class) {
+            runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
+        }
+        project.plugins.withType(JavaPlugin.class) {
+            runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
+        }
+        project.plugins.withType(JavaBasePlugin.class) {
+            runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
+        }
+
+//        project.plugins.withType(ScalaLanguagePlugin.class) { // TODO: do we want this instead?
         if (project.plugins.hasPlugin("scala")) {
             // the configurations `incrementalScalaAnalysisFor_x_ extend from `compile` and `implementation` rather than `compileClasspath`
             def scalaConfigurationsToLock = []

--- a/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
@@ -26,6 +26,8 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaLibraryPlugin
+import org.gradle.util.DeprecationLogger
+import org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper
 
 class CoreLockingHelper {
     private Project project
@@ -76,7 +78,13 @@ class CoreLockingHelper {
         project.plugins.withType(JavaLibraryPlugin.class) {
             runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
         }
-        project.plugins.withId("nebula.kotlin") {
+        DeprecationLogger.whileDisabled {
+            //TODO: remove deprecation logger disabled once we upgrade kotlin versions to one without deprecations
+            project.plugins.withType(KotlinBasePluginWrapper.class) {
+                runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
+            }
+        }
+        project.plugins.withId("nebula.clojure") {
             runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
         }
         project.plugins.withId("scala") {

--- a/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
@@ -26,7 +26,6 @@ import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaLibraryPlugin
-import org.gradle.api.plugins.JavaPlugin
 
 class CoreLockingHelper {
     private Project project
@@ -71,18 +70,16 @@ class CoreLockingHelper {
         project.plugins.withId("nebula.integtest") {
             runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
         }
-        project.plugins.withType(JavaLibraryPlugin.class) {
-            runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
-        }
-        project.plugins.withType(JavaPlugin.class) {
-            runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
-        }
         project.plugins.withType(JavaBasePlugin.class) {
             runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
         }
-
-//        project.plugins.withType(ScalaLanguagePlugin.class) { // TODO: do we want this instead?
-        if (project.plugins.hasPlugin("scala")) {
+        project.plugins.withType(JavaLibraryPlugin.class) {
+            runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
+        }
+        project.plugins.withId("nebula.kotlin") {
+            runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
+        }
+        project.plugins.withId("scala") {
             // the configurations `incrementalScalaAnalysisFor_x_ extend from `compile` and `implementation` rather than `compileClasspath`
             def scalaConfigurationsToLock = []
             project.configurations

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
@@ -313,7 +313,6 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
         buildFile << """\
             plugins {
                 id 'nebula.dependency-lock'
-                id 'java'
                 id 'nebula.kotlin' version '1.3.21'
             }
             repositories {
@@ -366,7 +365,6 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
         buildFile << """\
             plugins {
                 id 'nebula.dependency-lock'
-                id 'java'
             }
             allprojects {
                 task dependenciesForAll(type: DependencyReportTask) {}
@@ -380,7 +378,6 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
         addSubproject("sub1", """
             plugins {
                 id 'nebula.dependency-lock'
-                id 'java'
                 id 'nebula.kotlin' version '1.3.21'
             }
             dependencies {

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
@@ -333,12 +333,11 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
         result.output.contains('coreLockingSupport feature enabled')
         def actualLocks = new File(projectDir, '/gradle/dependency-locks/').list().toList()
 
-        def updatedExpectedLocks = expectedLocks + 'default.lockfile'
-        updatedExpectedLocks.each {
+        expectedLocks.each {
             assert actualLocks.contains(it)
         }
         actualLocks.each {
-            assert updatedExpectedLocks.contains(it)
+            assert expectedLocks.contains(it)
         }
 
         def lockFile = new File(projectDir, "/gradle/dependency-locks/${lockFileToVerify}.lockfile")
@@ -353,8 +352,8 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
 
         where:
         configuration    | lockFileToVerify
-        'compile'        | 'default'
-        'implementation' | 'default'
+        'compile'        | 'compileClasspath'
+        'implementation' | 'compileClasspath'
     }
 
     @Unroll
@@ -397,12 +396,11 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
         result.output.contains('coreLockingSupport feature enabled')
         def actualLocks = new File(projectDir, 'sub1/gradle/dependency-locks/').list().toList()
 
-        def updatedExpectedLocks = expectedLocks + 'default.lockfile'
-        updatedExpectedLocks.each {
+        expectedLocks.each {
             assert actualLocks.contains(it)
         }
         actualLocks.each {
-            assert updatedExpectedLocks.contains(it)
+            assert expectedLocks.contains(it)
         }
 
         def lockFile = new File(projectDir, "sub1/gradle/dependency-locks/${lockFileToVerify}.lockfile")
@@ -417,8 +415,8 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
 
         where:
         configuration    | lockFileToVerify
-        'compile'        | 'default'
-        'implementation' | 'default'
+        'compile'        | 'compileClasspath'
+        'implementation' | 'compileClasspath'
     }
 
     @Unroll


### PR DESCRIPTION
…rather than just when this plugin is loaded

- [JavaBasePlugin](https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/JavaBasePlugin.html) extends Object and implements Plugin
- [Java Plugin](https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/JavaPlugin.html) extends Object and implements Plugin
  - [Applies Java Base Plugin](https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java#L268)
  - Also [maybe creates more configurations](https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaPlugin.java#L461-L471)
- [JavaLibraryPlugin](https://docs.gradle.org/current/javadoc/org/gradle/api/plugins/JavaLibraryPlugin.html) extends Object and implements Plugin
  - [Applies Java Plugin](https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java#L35)
  - Sets its own [configurations](https://github.com/gradle/gradle/blob/master/subprojects/plugins/src/main/java/org/gradle/api/plugins/JavaLibraryPlugin.java#L38)
