### PR TITLE
Core locks: lock additional configurations…

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
@@ -42,6 +42,12 @@ class ConfigurationsToLockFinder {
 
         configurationsToLock.addAll(baseConfigurations)
 
+        def dependencyLockExtension = project.extensions.findByType(DependencyLockExtension)
+        def additionalConfigurationsToLock = project.hasProperty('dependencyLock.additionalConfigurationsToLock')
+                ? (project['dependencyLock.additionalConfigurationsToLock'] as String).split(",") as Set<String>
+                : dependencyLockExtension.additionalConfigurationsToLock as Set<String>
+        configurationsToLock.addAll(additionalConfigurationsToLock)
+
         def confSuffix = 'CompileClasspath'
         def configurationsWithPrefix = project.configurations.findAll { it.name.contains(confSuffix) }
         configurationsWithPrefix.each {

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
@@ -15,12 +15,9 @@
  */
 package nebula.plugin.dependencylock
 
-import nebula.plugin.dependencylock.wayback.WaybackProvider
-import nebula.plugin.dependencylock.wayback.WaybackProviderFactory
-
 class DependencyLockExtension {
     String lockFile = 'dependencies.lock'
-	String globalLockFile = 'global.lock'
+    String globalLockFile = 'global.lock'
     Set<String> configurationNames = [] as Set
     Closure dependencyFilter = { String group, String name, String version -> true }
     Set<String> updateDependencies = [] as Set
@@ -28,4 +25,5 @@ class DependencyLockExtension {
     boolean includeTransitives = false
     boolean lockAfterEvaluating = true
     Object waybackProvider
+    Set<String> additionalConfigurationsToLock = [] as Set
 }


### PR DESCRIPTION
via property or configuration of extension

Pass in additional configurations to lock via either:

* `-PdependencyLock.additionalConfigurationsToLock=comma,separated,configurations`
* configuring the DependencyLockExtension
