### PR TITLE
Core locks update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,10 +41,6 @@ contacts {
     }
 }
 
-ext {
-    kotlinVersion = '1.3.11'
-}
-
 dependencies {
     compile 'com.squareup.moshi:moshi:1.8.0'
     compile 'joda-time:joda-time:2.10'

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,6 @@ dependencies {
     compile 'com.squareup.moshi:moshi:1.8.0'
     compile 'joda-time:joda-time:2.10'
     compile 'com.netflix.nebula:nebula-gradle-interop:latest.release'
-    compile "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     compile 'com.netflix.nebula:gradle-scm-plugin:latest.release'
     compile 'com.netflix.nebula:gradle-metrics-plugin:8.+', optional
     compile 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.1'

--- a/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.logging.Logging
 
 class ConfigurationsToLockFinder {
     private static final Logger LOGGER = Logging.getLogger(ConfigurationsToLockFinder)
+    public static final String ADDITIONAL_CONFIGS_TO_LOCK = 'dependencyLock.additionalConfigurationsToLock'
     private Project project
 
     ConfigurationsToLockFinder(Project project) {
@@ -43,8 +44,8 @@ class ConfigurationsToLockFinder {
         configurationsToLock.addAll(baseConfigurations)
 
         def dependencyLockExtension = project.extensions.findByType(DependencyLockExtension)
-        def additionalConfigurationsToLock = project.hasProperty('dependencyLock.additionalConfigurationsToLock')
-                ? (project['dependencyLock.additionalConfigurationsToLock'] as String).split(",") as Set<String>
+        def additionalConfigurationsToLock = project.hasProperty(ADDITIONAL_CONFIGS_TO_LOCK)
+                ? (project[ADDITIONAL_CONFIGS_TO_LOCK] as String).split(",") as Set<String>
                 : dependencyLockExtension.additionalConfigurationsToLock as Set<String>
         configurationsToLock.addAll(additionalConfigurationsToLock)
 

--- a/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
@@ -26,14 +26,13 @@ import org.gradle.api.logging.Logging
 
 class ConfigurationsToLockFinder {
     private static final Logger LOGGER = Logging.getLogger(ConfigurationsToLockFinder)
-    public static final String ADDITIONAL_CONFIGS_TO_LOCK = 'dependencyLock.additionalConfigurationsToLock'
     private Project project
 
     ConfigurationsToLockFinder(Project project) {
         this.project = project
     }
 
-    List<String> findConfigurationsToLock(Set<String> configurationNames, List<String> additionalBaseConfigurationsToLock = new ArrayList<>()) {
+    List<String> findConfigurationsToLock(Set<String> configurationNames, Collection<String> additionalBaseConfigurationsToLock = new ArrayList<>()) {
         Collection<String> gatheredConfigurationNames = gatherConfigurationNames(additionalBaseConfigurationsToLock)
         Collection<String> lockableConfigurationNames = gatherLockableConfigurationNames(configurationNames, gatheredConfigurationNames)
         Collection<String> sortedLockableConfigNames = lockableConfigurationNames.sort()
@@ -50,15 +49,6 @@ class ConfigurationsToLockFinder {
         baseConfigurations.addAll(additionalBaseConfigurationsToLock)
 
         configurationsToLock.addAll(baseConfigurations)
-
-        def dependencyLockExtension = project.extensions.findByType(DependencyLockExtension)
-        def additionalConfigurationsToLockViaProperty = project.hasProperty(ADDITIONAL_CONFIGS_TO_LOCK)
-                ? (project[ADDITIONAL_CONFIGS_TO_LOCK] as String).split(",") as Set<String>
-                : []
-        def additionalConfigurationsToLockViaExtension = dependencyLockExtension.additionalConfigurationsToLock as Set<String>
-        
-        configurationsToLock.addAll(additionalConfigurationsToLockViaProperty)
-        configurationsToLock.addAll(additionalConfigurationsToLockViaExtension)
 
         def confSuffix = 'CompileClasspath'
         def configurationsWithPrefix = project.configurations.findAll { it.name.contains(confSuffix) }

--- a/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
@@ -52,10 +52,13 @@ class ConfigurationsToLockFinder {
         configurationsToLock.addAll(baseConfigurations)
 
         def dependencyLockExtension = project.extensions.findByType(DependencyLockExtension)
-        def additionalConfigurationsToLock = project.hasProperty(ADDITIONAL_CONFIGS_TO_LOCK)
+        def additionalConfigurationsToLockViaProperty = project.hasProperty(ADDITIONAL_CONFIGS_TO_LOCK)
                 ? (project[ADDITIONAL_CONFIGS_TO_LOCK] as String).split(",") as Set<String>
-                : dependencyLockExtension.additionalConfigurationsToLock as Set<String>
-        configurationsToLock.addAll(additionalConfigurationsToLock)
+                : []
+        def additionalConfigurationsToLockViaExtension = dependencyLockExtension.additionalConfigurationsToLock as Set<String>
+        
+        configurationsToLock.addAll(additionalConfigurationsToLockViaProperty)
+        configurationsToLock.addAll(additionalConfigurationsToLockViaExtension)
 
         def confSuffix = 'CompileClasspath'
         def configurationsWithPrefix = project.configurations.findAll { it.name.contains(confSuffix) }

--- a/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
@@ -20,16 +20,11 @@ package nebula.plugin.dependencylock.utils
 
 import nebula.plugin.dependencylock.ConfigurationsToLockFinder
 import nebula.plugin.dependencylock.tasks.GenerateLockTask
+import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
-import org.gradle.api.plugins.GroovyPlugin
-import org.gradle.api.plugins.JavaBasePlugin
-import org.gradle.api.plugins.JavaLibraryPlugin
-import org.gradle.api.plugins.JavaPlugin
-import org.gradle.util.DeprecationLogger
-import org.jetbrains.kotlin.gradle.plugin.KotlinBasePluginWrapper
 
 class CoreLockingHelper {
     private Project project
@@ -66,33 +61,7 @@ class CoreLockingHelper {
     }
 
     private void runClosureWhenPluginsAreSeen(Set<String> configurationNames, Closure closure) {
-        runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
-
-        project.plugins.withId("nebula.facet") { // FIXME: not working currently
-            runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
-        }
-        project.plugins.withId("nebula.integtest") {
-            runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
-        }
-        project.plugins.withType(GroovyPlugin.class) {
-            runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
-        }
-        project.plugins.withType(JavaBasePlugin.class) {
-            runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
-        }
-        project.plugins.withType(JavaPlugin.class) {
-            runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
-        }
-        project.plugins.withType(JavaLibraryPlugin.class) {
-            runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
-        }
-        DeprecationLogger.whileDisabled {
-            //TODO: remove deprecation logger disabled once we upgrade kotlin versions to one without deprecations
-            project.plugins.withType(KotlinBasePluginWrapper.class) {
-                runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
-            }
-        }
-        project.plugins.withId("nebula.clojure") {
+        project.plugins.withType(Plugin) { plugin ->
             runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
         }
         project.plugins.withId("scala") {

--- a/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.plugins.GroovyPlugin
 import org.gradle.api.plugins.JavaBasePlugin
 import org.gradle.api.plugins.JavaLibraryPlugin
 import org.gradle.api.plugins.JavaPlugin
@@ -71,6 +72,9 @@ class CoreLockingHelper {
             runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
         }
         project.plugins.withId("nebula.integtest") {
+            runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
+        }
+        project.plugins.withType(GroovyPlugin.class) {
             runClosureOnConfigurations(configurationNames, closure, new ArrayList<String>())
         }
         project.plugins.withType(JavaBasePlugin.class) {

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
@@ -559,17 +559,19 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
 
         where:
         languagePlugin   | languagePluginFirst | notes
+        'groovy'         | true                | 'applied first'
         'java'           | true                | 'applied first'
         'java-library'   | true                | 'applied first'
-        'scala'          | true                | 'applied first'
         'nebula.clojure' | true                | 'applied first'
         'nebula.kotlin'  | true                | 'applied first'
+        'scala'          | true                | 'applied first'
 
+        'groovy'         | false               | 'applied last'
         'java'           | false               | 'applied last'
         'java-library'   | false               | 'applied last'
-        'scala'          | false               | 'applied last'
         'nebula.clojure' | false               | 'applied last'
         'nebula.kotlin'  | false               | 'applied last'
+        'scala'          | false               | 'applied last'
     }
 
     def 'generate core lock should lock additional configurations via property'() {

--- a/src/test/groovy/nebula/plugin/dependencylock/dependencyfixture/WrapperPlugin.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/dependencyfixture/WrapperPlugin.groovy
@@ -1,0 +1,39 @@
+/**
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package nebula.plugin.dependencylock.dependencyfixture
+
+import nebula.plugin.dependencylock.DependencyLockExtension
+import nebula.plugin.dependencylock.DependencyLockPlugin
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class WrapperPlugin implements Plugin<Project> {
+    @Override
+    void apply(Project project) {
+        project.with {
+            plugins.apply('nebula.dependency-lock')
+
+            plugins.withType(DependencyLockPlugin) {
+                def extension = extensions.getByType(DependencyLockExtension)
+                extension.additionalConfigurationsToLock = ["spotbugs"]
+            }
+        }
+        project.logger.lifecycle('hello from test wrapper plugin')
+    }
+}

--- a/src/test/groovy/nebula/plugin/dependencylock/tasks/MigrateToCoreLocksTaskSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/tasks/MigrateToCoreLocksTaskSpec.groovy
@@ -10,10 +10,16 @@ import spock.lang.Unroll
 class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
     def expectedLocks = [
             'annotationProcessor.lockfile',
+            'compile.lockfile',
             'compileClasspath.lockfile',
+            'compileOnly.lockfile',
+            'runtime.lockfile',
             'runtimeClasspath.lockfile',
             'testAnnotationProcessor.lockfile',
+            'testCompile.lockfile',
             'testCompileClasspath.lockfile',
+            'testCompileOnly.lockfile',
+            'testRuntime.lockfile',
             'testRuntimeClasspath.lockfile'
     ] as String[]
     def mavenrepo

--- a/src/test/resources/META-INF/gradle-plugins/test.wrapper-plugin.properties
+++ b/src/test/resources/META-INF/gradle-plugins/test.wrapper-plugin.properties
@@ -1,0 +1,1 @@
+implementation-class=nebula.plugin.dependencylock.dependencyfixture.WrapperPlugin


### PR DESCRIPTION
* core locks will lock configurations that contribute to `compileClasspath`, `runtimeClasspath`, `annotationProcessor`, and their test- prefix configurations
* core locks can lock additional configurations via property and extension configuration
* core locks can lock custom configurations not added by a plugin