### PR TITLE
Core locks: lock the 'default' configuration

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
@@ -44,6 +44,7 @@ class ConfigurationsToLockFinder {
         def baseConfigurations = [
                 'annotationProcessor',
                 'compileClasspath',
+                'default',
                 'runtimeClasspath'
         ]
         baseConfigurations.addAll(additionalBaseConfigurationsToLock)

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
@@ -13,6 +13,7 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
             'compile.lockfile',
             'compileClasspath.lockfile',
             'compileOnly.lockfile',
+            'default.lockfile',
             'runtime.lockfile',
             'runtimeClasspath.lockfile',
             'testAnnotationProcessor.lockfile',

--- a/src/test/groovy/nebula/plugin/dependencylock/tasks/MigrateToCoreLocksTaskSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/tasks/MigrateToCoreLocksTaskSpec.groovy
@@ -13,6 +13,7 @@ class MigrateToCoreLocksTaskSpec extends IntegrationTestKitSpec {
             'compile.lockfile',
             'compileClasspath.lockfile',
             'compileOnly.lockfile',
+            'default.lockfile',
             'runtime.lockfile',
             'runtimeClasspath.lockfile',
             'testAnnotationProcessor.lockfile',


### PR DESCRIPTION
 It extends the runtime configuration