### PR TITLE
Core locking verify dependency resolution

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
@@ -158,7 +158,8 @@ class CoreLockingHelper {
 
                     @Override
                     void afterExecute(Task task, TaskState taskState) {
-                        if (task.path == lastTask.path && !taskState.failure) {
+                        def thisTaskPathIsLastTaskPath = task.path == lastTask.path // should happen only once
+                        if (thisTaskPathIsLastTaskPath && !taskState.failure) {
                             File gradleFilesDir = new File(project.projectDir, "gradle")
                             File lockfilesDir = new File(gradleFilesDir, "dependency-locks")
                             if (lockfilesDir.exists()) {

--- a/src/main/groovy/nebula/plugin/dependencylock/utils/DependencyResolutionVerifier.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/utils/DependencyResolutionVerifier.groovy
@@ -1,0 +1,136 @@
+/**
+ *
+ *  Copyright 2018 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package nebula.plugin.dependencylock.utils
+
+import nebula.plugin.dependencylock.exceptions.DependencyLockException
+import org.gradle.api.BuildCancelledException
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ResolveException
+import org.gradle.api.execution.TaskExecutionListener
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.api.tasks.TaskState
+import org.gradle.internal.locking.LockOutOfDateException
+
+class DependencyResolutionVerifier {
+    private static final Logger LOGGER = Logging.getLogger(DependencyResolutionVerifier.class)
+    private static final String UNRESOLVED_DEPENDENCIES_FAIL_THE_BUILD = 'dependencyLock.unresolvedDependenciesFailTheBuild'
+
+    static void verifySuccessfulResolution(Project project) {
+        Boolean unresolvedDependenciesShouldFailTheBuild = project.hasProperty(UNRESOLVED_DEPENDENCIES_FAIL_THE_BUILD)
+                ? (project.property(UNRESOLVED_DEPENDENCIES_FAIL_THE_BUILD) as String).toBoolean()
+                : true
+
+        Map<String, Set<Configuration>> failedDepsByConf = new HashMap<String, Set<Configuration>>()
+        Set<String> lockedDepsOutOfDate = new HashSet<>()
+
+        project.gradle.taskGraph.whenReady { taskGraph ->
+            LinkedList tasks = taskGraph.executionPlan.executionQueue
+            Task lastTask = tasks.last?.task
+            taskGraph.addTaskExecutionListener(new TaskExecutionListener() {
+                @Override
+                void beforeExecute(Task task) {
+                    //DO NOTHING
+                }
+
+                @Override
+                void afterExecute(Task task, TaskState taskState) {
+                    if (task.path == lastTask.path && !taskState.failure) {
+                        project.configurations.matching { // returns a live collection
+                            (it as Configuration).state != Configuration.State.UNRESOLVED &&
+                                    // the configurations `incrementalScalaAnalysisFor_x_` are resolvable only from a scala context
+                                    !(it as Configuration).name.startsWith('incrementalScala')
+                        }.all {
+                            conf ->
+                                LOGGER.debug("$conf has state ${conf.state}. Starting dependency resolution verification.")
+                                try {
+                                    conf.resolvedConfiguration.resolvedArtifacts
+                                } catch (ResolveException re) {
+                                    re.causes.each {
+                                        if (LockOutOfDateException.class == it.class) {
+                                            lockedDepsOutOfDate.add(it.getMessage())
+                                        } else {
+                                            String dep = it.selector.toString()
+                                            if (failedDepsByConf.containsKey(dep)) {
+                                                failedDepsByConf.get(dep).add(conf as Configuration)
+                                            } else {
+                                                Set<Configuration> failedConfs = new HashSet<Configuration>()
+                                                failedConfs.add(conf as Configuration)
+
+                                                failedDepsByConf.put(dep, failedConfs)
+                                            }
+                                        }
+                                    }
+                                }
+                        }
+                    }
+
+                    if (task.name == lastTask.name && task.project == lastTask.project && !taskState.failure) {
+                        // run after last task on last project
+                        if (failedDepsByConf.size() != 0 || lockedDepsOutOfDate.size() != 0) {
+                            List<String> message = new ArrayList<>()
+                            List<String> debugMessage = new ArrayList<>()
+                            try {
+                                if (failedDepsByConf.size() > 0) {
+                                    message.add("Failed to resolve the following dependencies:")
+                                }
+                                failedDepsByConf
+                                        .sort()
+                                        .eachWithIndex { it, index ->
+                                            def dep = it.key
+                                            def failedConfs = it.value
+                                            message.add("  ${index + 1}) Failed to resolve '$dep' for project '${project.name}'")
+                                            debugMessage.add("Failed to resolve $dep on:")
+                                            failedConfs
+                                                    .sort { a, b -> a.name <=> b.name }
+                                                    .each { failedConf ->
+                                                        debugMessage.add("  - $failedConf")
+                                                    }
+                                        }
+
+                                if (lockedDepsOutOfDate.size() > 0) {
+                                    message.add('Resolved dependencies were missing from the lock state:')
+                                }
+                                lockedDepsOutOfDate
+                                        .sort()
+                                        .eachWithIndex { outOfDateMessage, index ->
+                                            message.add("  ${index + 1}) $outOfDateMessage for project '${project.name}'")
+                                        }
+
+                            } catch (Exception e) {
+                                throw new BuildCancelledException("Error creating message regarding failed dependencies", e)
+                            }
+                            if (unresolvedDependenciesShouldFailTheBuild) {
+                                LOGGER.debug(debugMessage.join('\n'))
+                                throw new DependencyLockException(message.join('\n'))
+                            } else {
+                                LOGGER.debug(debugMessage.join('\n'))
+                                LOGGER.warn(message.join('\n'))
+                            }
+                        }
+                    }
+                }
+            }
+
+            )
+        }
+    }
+}

--- a/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
+++ b/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
@@ -19,6 +19,7 @@ import com.netflix.nebula.interop.onResolve
 import nebula.plugin.dependencylock.exceptions.DependencyLockException
 import nebula.plugin.dependencylock.utils.CoreLocking
 import nebula.plugin.dependencylock.utils.CoreLockingHelper
+import nebula.plugin.dependencylock.utils.DependencyResolutionVerifier
 import org.gradle.api.BuildCancelledException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -76,6 +77,13 @@ class DependencyLockPlugin : Plugin<Project> {
             LOGGER.warn("${project.name}: coreLockingSupport feature enabled")
             val coreLockingHelper = CoreLockingHelper(project)
             coreLockingHelper.lockSelectedConfigurations(extension.configurationNames)
+
+            if (!project.gradle.startParameter.taskNames.contains(DependencyLockTaskConfigurer.MIGRATE_TO_CORE_LOCKS_TASK_NAME)) {
+                /* MigrateToCoreLocks can be involved with migrating dependencies that were previously unlocked.
+                   Verifying resolution based on the base lockfiles causes a `LockOutOfDateException` from the initial DependencyLockingArtifactVisitor state
+                */
+                DependencyResolutionVerifier.verifySuccessfulResolution(project)
+            }
 
             val lockFile = File(project.projectDir, extension.lockFile)
 

--- a/src/test/groovy/nebula/plugin/dependencylock/AbstractDependencyLockPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/AbstractDependencyLockPluginSpec.groovy
@@ -1,0 +1,109 @@
+package nebula.plugin.dependencylock
+
+import nebula.test.IntegrationTestKitSpec
+import nebula.test.dependencies.DependencyGraphBuilder
+import nebula.test.dependencies.GradleDependencyGenerator
+import nebula.test.dependencies.ModuleBuilder
+
+class AbstractDependencyLockPluginSpec extends IntegrationTestKitSpec {
+    def expectedLocks = [
+            'annotationProcessor.lockfile',
+            'compile.lockfile',
+            'compileClasspath.lockfile',
+            'compileOnly.lockfile',
+            'default.lockfile',
+            'runtime.lockfile',
+            'runtimeClasspath.lockfile',
+            'testAnnotationProcessor.lockfile',
+            'testCompile.lockfile',
+            'testCompileClasspath.lockfile',
+            'testCompileOnly.lockfile',
+            'testRuntime.lockfile',
+            'testRuntimeClasspath.lockfile'
+    ] as String[]
+    def mavenrepo
+    def projectName
+
+    def setup() {
+        keepFiles = true
+        new File("${projectDir}/gradle.properties").text = "systemProp.nebula.features.coreLockingSupport=true"
+
+        projectName = getProjectDir().getName().replaceAll(/_\d+/, '')
+        settingsFile << """\
+            rootProject.name = '${projectName}'
+        """.stripIndent()
+
+        def graph = new DependencyGraphBuilder()
+                .addModule('test.nebula:a:1.0.0')
+                .addModule('test.nebula:a:1.1.0')
+                .addModule('test.nebula:b:1.0.0')
+                .addModule('test.nebula:b:1.1.0')
+                .addModule('test.nebula:d:1.0.0')
+                .addModule('test.nebula:d:1.1.0')
+                .addModule(new ModuleBuilder('test.nebula:c:1.0.0').addDependency('test.nebula:d:1.0.0').build())
+                .addModule(new ModuleBuilder('test.nebula:c:1.1.0').addDependency('test.nebula:d:1.1.0').build())
+                .build()
+        mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen")
+        mavenrepo.generateTestMavenRepo()
+
+        buildFile << """\
+            plugins {
+                id 'nebula.dependency-lock'
+                id 'java'
+            }
+            repositories {
+                ${mavenrepo.mavenRepositoryBlock}
+            }
+            dependencies {
+                compile 'test.nebula:a:1.+'
+                compile 'test.nebula:b:1.+'
+            }
+        """.stripIndent()
+
+        debug = true // if you want to debug with IntegrationTestKit, this is needed
+    }
+
+    def setupScalaProject(String conf) {
+        buildFile.delete()
+        buildFile.createNewFile()
+        buildFile << """
+            plugins {
+                id 'scala'
+                id 'nebula.dependency-lock'
+            }
+            repositories {
+                jcenter()
+            }
+            dependencies {
+                $conf 'org.scala-lang:scala-library:2.12.7'
+            
+                test${conf.capitalize()} 'junit:junit:4.12'
+                test${conf.capitalize()} 'org.scalatest:scalatest_2.12:3.0.5'
+            
+                testRuntimeOnly 'org.scala-lang.modules:scala-xml_2.12:1.1.1'
+            }
+            """.stripIndent()
+
+        def scalaFile = createFile("src/main/scala/Library.scala")
+        scalaFile << """
+            class Library {
+              def someLibraryMethod(): Boolean = true
+            }
+            """.stripIndent()
+
+        def scalaTest = createFile("src/test/scala/LibrarySuite.scala")
+        scalaTest << """
+            import org.scalatest.FunSuite
+            import org.junit.runner.RunWith
+            import org.scalatest.junit.JUnitRunner
+            
+            @RunWith(classOf[JUnitRunner])
+            class LibrarySuite extends FunSuite {
+              test("someLibraryMethod is always true") {
+                def library = new Library()
+                assert(library.someLibraryMethod)
+              }
+            }
+            """.stripIndent()
+    }
+}

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
@@ -1,70 +1,11 @@
 package nebula.plugin.dependencylock
 
 import nebula.plugin.dependencylock.util.LockGenerator
-import nebula.test.IntegrationTestKitSpec
 import nebula.test.dependencies.DependencyGraphBuilder
 import nebula.test.dependencies.GradleDependencyGenerator
-import nebula.test.dependencies.ModuleBuilder
 import spock.lang.Unroll
 
-class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
-    def expectedLocks = [
-            'annotationProcessor.lockfile',
-            'compile.lockfile',
-            'compileClasspath.lockfile',
-            'compileOnly.lockfile',
-            'default.lockfile',
-            'runtime.lockfile',
-            'runtimeClasspath.lockfile',
-            'testAnnotationProcessor.lockfile',
-            'testCompile.lockfile',
-            'testCompileClasspath.lockfile',
-            'testCompileOnly.lockfile',
-            'testRuntime.lockfile',
-            'testRuntimeClasspath.lockfile'
-    ] as String[]
-    def mavenrepo
-    def projectName
-
-    def setup() {
-        keepFiles = true
-        new File("${projectDir}/gradle.properties").text = "systemProp.nebula.features.coreLockingSupport=true"
-
-        projectName = getProjectDir().getName().replaceAll(/_\d+/, '')
-        settingsFile << """\
-            rootProject.name = '${projectName}'
-        """.stripIndent()
-
-        def graph = new DependencyGraphBuilder()
-                .addModule('test.nebula:a:1.0.0')
-                .addModule('test.nebula:a:1.1.0')
-                .addModule('test.nebula:b:1.0.0')
-                .addModule('test.nebula:b:1.1.0')
-                .addModule('test.nebula:d:1.0.0')
-                .addModule('test.nebula:d:1.1.0')
-                .addModule(new ModuleBuilder('test.nebula:c:1.0.0').addDependency('test.nebula:d:1.0.0').build())
-                .addModule(new ModuleBuilder('test.nebula:c:1.1.0').addDependency('test.nebula:d:1.1.0').build())
-                .build()
-        mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen")
-        mavenrepo.generateTestMavenRepo()
-
-        buildFile << """\
-            plugins {
-                id 'nebula.dependency-lock'
-                id 'java'
-            }
-            repositories {
-                ${mavenrepo.mavenRepositoryBlock}
-            }
-            dependencies {
-                compile 'test.nebula:a:1.+'
-                compile 'test.nebula:b:1.+'
-            }
-        """.stripIndent()
-
-        debug = true // if you want to debug with IntegrationTestKit, this is needed
-    }
-
+class DependencyLockPluginWithCoreSpec extends AbstractDependencyLockPluginSpec {
     def 'generate core lock file'() {
         when:
         def result = runTasks('dependencies', '--write-locks')
@@ -171,13 +112,13 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
         mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen")
         mavenrepo.generateTestMavenRepo()
 
-        def dependencyInsightCompileClasspath = runTasks('dependencyInsight', '--dependency', 'test.nebula:a', '--configuration', 'compileClasspath')
-        def dependencyInsightCompile = runTasks('dependencyInsight', '--dependency', 'test.nebula:a', '--configuration', 'compile')
+        def depInsightCompileClasspathWithLockedDeps = runTasks('dependencyInsight', '--dependency', 'test.nebula:a', '--configuration', 'compileClasspath')
+        def depInsightCompileWithLockedDeps = runTasks('dependencyInsight', '--dependency', 'test.nebula:a', '--configuration', 'compile')
 
         then:
         // different configurations should use the same version before updating locks
-        dependencyInsightCompileClasspath.output.contains('test.nebula:a:1.1.0')
-        dependencyInsightCompile.output.contains('test.nebula:a:1.1.0')
+        depInsightCompileClasspathWithLockedDeps.output.contains('test.nebula:a:1.1.0')
+        depInsightCompileWithLockedDeps.output.contains('test.nebula:a:1.1.0')
 
         when:
         def result = runTasks('dependencies', '--write-locks')
@@ -855,7 +796,6 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
         assert !customConfigurationLockFile.exists()
     }
 
-
     def 'generate core lock should lock delete stale lockfiles when regenerating - multiproject setup'() {
         given:
         definePluginOutsideOfPluginBlock = true
@@ -1117,7 +1057,7 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
 
         then:
         expectedLocks.each {
-            def lockingDebugMessage = "Locking configuration ':${it.split('.lockfile').first()}'"
+            def lockingDebugMessage = "Activated configuration ':${it.split('.lockfile').first()}' for dependency locking"
             assert result.output.contains(lockingDebugMessage)
             assert result.output.findAll(lockingDebugMessage).size() == 1
         }
@@ -1244,50 +1184,6 @@ class DependencyLockPluginWithCoreSpec extends IntegrationTestKitSpec {
         result.output.contains("Please use `./gradlew dependencies --update-locks group1:module1,group2:module2`")
         result.output.contains("> Task :updateLock FAILED")
         assertNoErrorsOnAParticularBuildLine(result.output)
-    }
-
-    private setupScalaProject(String conf) {
-        buildFile.delete()
-        buildFile.createNewFile()
-        buildFile << """
-            plugins {
-                id 'scala'
-                id 'nebula.dependency-lock'
-            }
-            repositories {
-                jcenter()
-            }
-            dependencies {
-                $conf 'org.scala-lang:scala-library:2.12.7'
-            
-                test${conf.capitalize()} 'junit:junit:4.12'
-                test${conf.capitalize()} 'org.scalatest:scalatest_2.12:3.0.5'
-            
-                testRuntimeOnly 'org.scala-lang.modules:scala-xml_2.12:1.1.1'
-            }
-            """.stripIndent()
-
-        def scalaFile = createFile("src/main/scala/Library.scala")
-        scalaFile << """
-            class Library {
-              def someLibraryMethod(): Boolean = true
-            }
-            """.stripIndent()
-
-        def scalaTest = createFile("src/test/scala/LibrarySuite.scala")
-        scalaTest << """
-            import org.scalatest.FunSuite
-            import org.junit.runner.RunWith
-            import org.scalatest.junit.JUnitRunner
-            
-            @RunWith(classOf[JUnitRunner])
-            class LibrarySuite extends FunSuite {
-              test("someLibraryMethod is always true") {
-                def library = new Library()
-                assert(library.someLibraryMethod)
-              }
-            }
-            """.stripIndent()
     }
 
     private static void assertNoErrorsOnAParticularBuildLine(String text) {

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreVerifierSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreVerifierSpec.groovy
@@ -1,0 +1,656 @@
+package nebula.plugin.dependencylock
+
+import nebula.test.dependencies.DependencyGraphBuilder
+import nebula.test.dependencies.GradleDependencyGenerator
+import nebula.test.dependencies.ModuleBuilder
+import spock.lang.Unroll
+
+class DependencyLockPluginWithCoreVerifierSpec extends AbstractDependencyLockPluginSpec {
+    private static final String BASELINE_LOCKFILE_CONTENTS = """# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+test.nebula:a:1.1.0
+test.nebula:b:1.1.0
+""".stripIndent()
+
+    private static final String MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES = """ \
+        dependencies {
+            compile 'test.nebula:d:1.0.0'
+            testCompile 'test.nebula:c' // missing from a BOM, for example
+            testRuntime 'test.nebula:e' // missing from a BOM, for example
+            testRuntime 'has.missing.transitive:a:1.0.0' // transitive dep not found
+            testRuntime 'not.available:a:1.0.0' // has version number, but not found
+        }
+        """.stripIndent()
+
+    def setup() {
+        def graph = new DependencyGraphBuilder()
+                .addModule('test.nebula:e:1.0.0')
+                .addModule('test.nebula:f:1.0.0')
+                .addModule(new ModuleBuilder('has.missing.transitive:a:1.0.0').addDependency('transitive.not.available:a:1.0.0').build())
+                .build()
+        mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen")
+        mavenrepo.generateTestMavenRepo()
+
+        def transitiveNotAvailableDep = new File(mavenrepo.getMavenRepoDir(), "transitive/not/available/a")
+        transitiveNotAvailableDep.deleteDir() // to create a missing transitive dependency
+    }
+
+    @Unroll
+    def 'fail when dependency is unresolvable upon update via #lockArg'() {
+        given:
+        createSingleProjectBaseline()
+
+        when:
+        buildFile << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
+
+        def results = runTasksAndFail(*tasks(lockArg))
+
+        then:
+        results.output.contains('FAILURE')
+
+        where:
+        lockArg << ['write-locks', 'update-locks']
+    }
+
+    @Unroll
+    def 'warn when dependency is unresolvable upon update via #lockArg and project requests warnings only via property'() {
+        given:
+        createSingleProjectBaseline()
+
+        when:
+        buildFile << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
+
+        def results = runTasks(*tasks(lockArg), '-PdependencyLock.unresolvedDependenciesFailTheBuild=false')
+
+        then:
+        results.output.contains("Failed to resolve the following dependencies")
+        results.output.contains(failedResolutionDependencies())
+
+        where:
+        lockArg << ['write-locks', 'update-locks']
+    }
+
+    @Unroll
+    def 'fail when dependency is missing from the lock state'() {
+        given:
+        createSingleProjectBaseline()
+
+        when:
+        buildFile << """ \
+        dependencies {
+            compile 'test.nebula:d:1.0.0'
+        }
+        """.stripIndent()
+
+        def results = runTasksAndFail('dependencies')
+
+        then:
+        results.output.contains('FAILURE')
+        results.output.contains('Resolved dependencies were missing from the lock state')
+        results.output.contains('Resolved \'test.nebula:d:1.0.0\' which is not part of the dependency lock state')
+    }
+
+    @Unroll
+    def 'multiproject: fail when dependency is unresolvable upon update via #lockArg'() {
+        given:
+        createMultiProjectBaseline()
+
+        when:
+        new File(projectDir, 'sub1/build.gradle') << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
+        new File(projectDir, 'sub2/build.gradle') << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
+
+        def results = runTasksAndFail(*tasks(lockArg, true))
+
+        then:
+        results.output.contains('FAILURE')
+
+        where:
+        lockArg << ['write-locks', 'update-locks']
+    }
+
+    @Unroll
+    def 'multiproject: fail when dependency is missing from the lock state'() {
+        given:
+        createMultiProjectBaseline()
+        def graph = new DependencyGraphBuilder()
+                .addModule('test.nebula:e:1.0.0')
+                .build()
+        mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen")
+        mavenrepo.generateTestMavenRepo()
+
+        when:
+        new File(projectDir, 'sub1/build.gradle') << """ \
+        dependencies {
+            compile 'test.nebula:d:1.0.0'
+        }
+        """.stripIndent()
+        new File(projectDir, 'sub2/build.gradle') << """ \
+        dependencies {
+            compile 'test.nebula:e:1.0.0'
+        }
+        """.stripIndent()
+
+        def results = runTasksAndFail('dependenciesForAll')
+
+        then:
+        results.output.contains('FAILURE')
+        results.output.contains('Resolved dependencies were missing from the lock state')
+        results.output.contains('Resolved \'test.nebula:d:1.0.0\' which is not part of the dependency lock state')
+        results.output.contains('Resolved \'test.nebula:e:1.0.0\' which is not part of the dependency lock state')
+    }
+
+    @Unroll
+    def 'provide useful error message when dependency is unresolvable upon update via #lockArg'() {
+        given:
+        createSingleProjectBaseline()
+
+        when:
+        buildFile << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
+
+        def results = runTasksAndFail(*tasks(lockArg))
+
+        then:
+        results.output.contains('test.nebula:c FAILED')
+        results.output.contains('test.nebula:e FAILED')
+        results.output.contains('not.available:a:1.0.0 FAILED')
+        results.output.contains('transitive.not.available:a:1.0.0 FAILED')
+        results.output.contains('FAILURE')
+
+        results.output.contains("> Failed to resolve the following dependencies")
+        results.output.contains(failedResolutionDependencies())
+
+        where:
+        lockArg << ['write-locks', 'update-locks']
+    }
+
+    @Unroll
+    def 'multiproject: provide useful error message when dependency is unresolvable upon update via #lockArg'() {
+        given:
+        createMultiProjectBaseline()
+
+        when:
+        new File(projectDir, 'sub1/build.gradle') << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
+        new File(projectDir, 'sub2/build.gradle') << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
+
+        def results = runTasksAndFail(*tasks(lockArg, true))
+
+        then:
+        results.output.contains('test.nebula:c FAILED')
+        results.output.contains('test.nebula:e FAILED')
+        results.output.contains('not.available:a:1.0.0 FAILED')
+        results.output.contains('transitive.not.available:a:1.0.0 FAILED')
+        results.output.contains('FAILURE')
+
+        results.output.contains("> Failed to resolve the following dependencies")
+        results.output.contains(failedResolutionDependencies('sub1'))
+
+        results.output.contains("""
+       1) Failed to resolve 'not.available:a:1.0.0' for project 'sub2'
+       2) Failed to resolve 'test.nebula:c' for project 'sub2'
+       3) Failed to resolve 'test.nebula:e' for project 'sub2'
+       4) Failed to resolve 'transitive.not.available:a:1.0.0' for project 'sub2'""")
+
+        where:
+        lockArg << ['write-locks', 'update-locks']
+    }
+
+    @Unroll
+    def 'update lockfiles for resolvable configurations only upon update via #lockArg'() {
+        given:
+        createSingleProjectBaseline()
+
+        when:
+        buildFile << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
+
+        def results = runTasksAndFail(*tasks(lockArg))
+
+        then:
+        def secondRunCompileLockfile = new File(projectDir, '/gradle/dependency-locks/compileClasspath.lockfile')
+        secondRunCompileLockfile.text == BASELINE_LOCKFILE_CONTENTS + "test.nebula:d:1.0.0\n"
+
+        def secondRunTestCompileLockfile = new File(projectDir, '/gradle/dependency-locks/testCompileClasspath.lockfile')
+        assert secondRunTestCompileLockfile.exists()
+        secondRunTestCompileLockfile.text == BASELINE_LOCKFILE_CONTENTS
+
+        where:
+        lockArg << ['write-locks', 'update-locks']
+    }
+
+    @Unroll
+    def 'multiproject: update lockfiles for resolvable configurations only upon update via #lockArg'() {
+        given:
+        createMultiProjectBaseline()
+
+        when:
+        new File(projectDir, 'sub1/build.gradle') << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
+        new File(projectDir, 'sub2/build.gradle') << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
+
+        def results = runTasksAndFail(*tasks(lockArg, true))
+
+        then:
+        def secondRunCompileLockfile = new File(projectDir, 'sub1/gradle/dependency-locks/compileClasspath.lockfile')
+        secondRunCompileLockfile.text == BASELINE_LOCKFILE_CONTENTS + "test.nebula:d:1.0.0\n"
+
+        def secondRunTestCompileLockfile = new File(projectDir, 'sub1/gradle/dependency-locks/testCompileClasspath.lockfile')
+        assert secondRunTestCompileLockfile.exists()
+        secondRunTestCompileLockfile.text == BASELINE_LOCKFILE_CONTENTS
+
+        where:
+        lockArg << ['write-locks', 'update-locks']
+    }
+
+    @Unroll
+    def 'scala: fail when dependency is unresolvable upon update via #lockArg (defining dependencies on base configuration "#conf")'() {
+        // the configurations `incrementalScalaAnalysisFor_x_` are resolvable only from a scala context, and extend from `compile` and `implementation`
+        // https://github.com/gradle/gradle/blob/master/subprojects/scala/src/main/java/org/gradle/api/plugins/scala/ScalaBasePlugin.java#L143
+        given:
+        createSingleProjectBaseline('scala', conf)
+
+        when:
+        buildFile << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
+
+        def results = runTasksAndFail(*tasks(lockArg))
+
+        then:
+        results.output.contains('test.nebula:c FAILED')
+        results.output.contains('test.nebula:e FAILED')
+        results.output.contains('not.available:a:1.0.0 FAILED')
+        results.output.contains('transitive.not.available:a:1.0.0 FAILED')
+        results.output.contains('FAILURE')
+
+        results.output.contains("> Failed to resolve the following dependencies")
+        results.output.contains(failedResolutionDependencies())
+
+        where:
+        conf             | lockArg
+        'compile'        | "write-locks"
+        'compile'        | "update-locks"
+        'implementation' | "write-locks"
+        'implementation' | "update-locks"
+    }
+
+    @Unroll
+    def 'groovy: fail when dependency is unresolvable upon update via #lockArg'() {
+        given:
+        createSingleProjectBaseline('groovy')
+
+        when:
+        buildFile << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
+
+        def results = runTasksAndFail(*tasks(lockArg))
+
+        then:
+        results.output.contains('FAILURE')
+        results.output.contains(failedResolutionDependencies())
+
+        where:
+        lockArg << ['write-locks', 'update-locks']
+    }
+
+    @Unroll
+    def 'java-library: fail when dependency is unresolvable upon update via #lockArg'() {
+        given:
+        createSingleProjectBaseline('java-library')
+
+        when:
+        buildFile << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
+
+        def results = runTasksAndFail(*tasks(lockArg))
+
+        then:
+        results.output.contains('FAILURE')
+        results.output.contains(failedResolutionDependencies())
+
+        where:
+        lockArg << ['write-locks', 'update-locks']
+    }
+
+    @Unroll
+    def 'nebula.kotlin: fail when dependency is unresolvable upon update via #lockArg'() {
+        given:
+        createSingleProjectBaseline('nebula.kotlin')
+
+        when:
+        buildFile << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
+
+        def results = runTasksAndFail(*tasks(lockArg))
+
+        then:
+        results.output.contains('FAILURE')
+        results.output.contains(failedResolutionDependencies())
+
+        where:
+        lockArg << ['write-locks', 'update-locks']
+    }
+
+    @Unroll
+    def 'nebula.clojure: fail when dependency is unresolvable upon update via #lockArg'() {
+        given:
+        createSingleProjectBaseline('nebula.clojure')
+
+        when:
+        buildFile << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
+
+        def results = runTasksAndFail(*tasks(lockArg))
+
+        then:
+        results.output.contains('FAILURE')
+        results.output.contains(failedResolutionDependencies())
+
+        where:
+        lockArg << ['write-locks', 'update-locks']
+    }
+
+    def createSingleProjectBaseline(String languagePlugin = 'java', String conf = '') {
+        if (languagePlugin == 'nebula.kotlin') {
+            createKotlinSingleProjectBaseline()
+            return
+        }
+        if (languagePlugin == 'nebula.clojure') {
+            createClojureSingleProjectBaseline()
+            return
+        }
+        if (languagePlugin == 'scala') {
+            createScalaSingleProjectBaseline(conf)
+            return
+        }
+        if (languagePlugin != 'java') {
+            updateSingleProjectFor(languagePlugin)
+        }
+        writeHelloWorld()
+        writeUnitTest()
+
+        runTasks('dependencies', '--write-locks') // baseline dependency locks
+
+        def actualLocks = new File(projectDir, '/gradle/dependency-locks/').list().toList()
+
+        expectedLocks.each {
+            assert actualLocks.contains(it)
+        }
+        actualLocks.each {
+            assert expectedLocks.contains(it)
+        }
+        def firstRunCompileLockfile = new File(projectDir, '/gradle/dependency-locks/compileClasspath.lockfile')
+        assert firstRunCompileLockfile.text == BASELINE_LOCKFILE_CONTENTS
+
+        def firstRunTestCompileLockfile = new File(projectDir, '/gradle/dependency-locks/testCompileClasspath.lockfile')
+        assert firstRunTestCompileLockfile.text == BASELINE_LOCKFILE_CONTENTS
+
+        if (languagePlugin == 'nebula.kotlin') {
+            System.setProperty("ignoreDeprecations", "false")
+        }
+    }
+
+    def createMultiProjectBaseline() {
+        buildFile.delete()
+        buildFile.createNewFile()
+        buildFile << """
+            plugins {
+                id 'java'
+            }
+            subprojects {
+                task dependenciesForAll(type: DependencyReportTask) {}
+            }
+            """.stripIndent()
+
+        def subProjectBuildFileContent = """
+            plugins {
+                id 'nebula.dependency-lock'
+                id 'java'
+            }
+            repositories {
+                ${mavenrepo.mavenRepositoryBlock}
+            }
+            dependencies {
+                compile 'test.nebula:a:1.+'
+                compile 'test.nebula:b:1.+'
+            }
+            """.stripIndent()
+
+        addSubproject("sub1", subProjectBuildFileContent)
+        addSubproject("sub2", subProjectBuildFileContent)
+
+        writeHelloWorld(new File(projectDir, 'sub1'))
+        writeHelloWorld(new File(projectDir, 'sub2'))
+        writeUnitTest(new File(projectDir, 'sub1'))
+        writeUnitTest(new File(projectDir, 'sub2'))
+
+        runTasks('dependenciesForAll', '--write-locks') // baseline dependency locks
+
+        def sub1ActualLocks = new File(projectDir, 'sub1/gradle/dependency-locks/').list().toList()
+
+        expectedLocks.each {
+            assert sub1ActualLocks.contains(it)
+        }
+        sub1ActualLocks.each {
+            assert expectedLocks.contains(it)
+        }
+
+        def sub2ActualLocks = new File(projectDir, 'sub2/gradle/dependency-locks/').list().toList()
+
+        expectedLocks.each {
+            assert sub2ActualLocks.contains(it)
+        }
+        sub2ActualLocks.each {
+            assert expectedLocks.contains(it)
+        }
+
+        def firstRunCompileLockfile = new File(projectDir, 'sub1/gradle/dependency-locks/compileClasspath.lockfile')
+        assert firstRunCompileLockfile.text == BASELINE_LOCKFILE_CONTENTS
+
+        def firstRunTestCompileLockfile = new File(projectDir, 'sub1/gradle/dependency-locks/testCompileClasspath.lockfile')
+        assert firstRunTestCompileLockfile.text == BASELINE_LOCKFILE_CONTENTS
+    }
+
+    def createScalaSingleProjectBaseline(String conf) {
+        setupScalaProject(conf)
+
+        buildFile << """
+            repositories {
+                ${mavenrepo.mavenRepositoryBlock}
+            }
+            dependencies {
+                compile 'test.nebula:a:1.+'
+                compile 'test.nebula:b:1.+'
+            }
+            """.stripIndent()
+
+        runTasks('dependencies', '--write-locks') // baseline dependency locks
+
+        def actualLocks = new File(projectDir, '/gradle/dependency-locks/').list().toList()
+
+        expectedLocks.each {
+            assert actualLocks.contains(it)
+        }
+        actualLocks.each {
+            assert expectedLocks.contains(it)
+        }
+        def firstRunCompileLockfile = new File(projectDir, '/gradle/dependency-locks/compileClasspath.lockfile')
+        assert firstRunCompileLockfile.text ==
+                """# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.scala-lang:scala-library:2.12.7
+test.nebula:a:1.1.0
+test.nebula:b:1.1.0
+"""
+
+        def firstRunTestCompileLockfile = new File(projectDir, '/gradle/dependency-locks/testCompileClasspath.lockfile')
+        assert firstRunTestCompileLockfile.text ==
+                """# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+junit:junit:4.12
+org.hamcrest:hamcrest-core:1.3
+org.scala-lang.modules:scala-xml_2.12:1.0.6
+org.scala-lang:scala-library:2.12.7
+org.scala-lang:scala-reflect:2.12.4
+org.scalactic:scalactic_2.12:3.0.5
+org.scalatest:scalatest_2.12:3.0.5
+test.nebula:a:1.1.0
+test.nebula:b:1.1.0
+"""
+    }
+
+    def createKotlinSingleProjectBaseline() {
+        buildFile.delete()
+        buildFile.createNewFile()
+
+        buildFile << """\
+                buildscript {
+                    repositories { maven { url "https://plugins.gradle.org/m2/" } }
+                    dependencies {
+                        classpath "com.netflix.nebula:nebula-kotlin-plugin:latest.release"
+                    }
+                }
+                plugins {
+                    id 'nebula.dependency-lock'
+                }
+                apply plugin: 'nebula.kotlin'
+                repositories {
+                    ${mavenrepo.mavenRepositoryBlock}
+                    mavenCentral()
+                }
+                dependencies {
+                    compile 'test.nebula:a:1.+'
+                    compile 'test.nebula:b:1.+'
+                }
+                """.stripIndent()
+        System.setProperty("ignoreDeprecations", "true")
+
+        runTasks('dependencies', '--write-locks') // baseline dependency locks
+
+        def actualLocks = new File(projectDir, '/gradle/dependency-locks/').list().toList()
+
+        expectedLocks.each {
+            assert actualLocks.contains(it)
+        }
+        actualLocks.each {
+            assert expectedLocks.contains(it)
+        }
+        def firstRunCompileLockfile = new File(projectDir, '/gradle/dependency-locks/compileClasspath.lockfile')
+        def lockfileContents = """# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.jetbrains.kotlin:kotlin-stdlib-common:1.3.50
+org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.3.50
+org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.50
+org.jetbrains.kotlin:kotlin-stdlib:1.3.50
+org.jetbrains:annotations:13.0
+test.nebula:a:1.1.0
+test.nebula:b:1.1.0
+"""
+        assert firstRunCompileLockfile.text == lockfileContents
+
+        def firstRunTestCompileLockfile = new File(projectDir, '/gradle/dependency-locks/testCompileClasspath.lockfile')
+        assert firstRunTestCompileLockfile.text == lockfileContents
+    }
+
+    def createClojureSingleProjectBaseline() {
+        buildFile.delete()
+        buildFile.createNewFile()
+
+        buildFile << """\
+                buildscript {
+                    repositories { maven { url "https://plugins.gradle.org/m2/" } }
+                    dependencies {
+                        classpath "com.netflix.nebula:nebula-clojure-plugin:latest.release"
+                    }
+                }
+                plugins {
+                    id 'nebula.dependency-lock'
+                }
+                apply plugin: 'nebula.clojure'
+                repositories {
+                    ${mavenrepo.mavenRepositoryBlock}
+                    mavenCentral()
+                }
+                dependencies {
+                    compile 'org.clojure:clojure:1.8.0'
+                    compile 'test.nebula:a:1.+'
+                    compile 'test.nebula:b:1.+'
+                }
+                """.stripIndent()
+        System.setProperty("ignoreDeprecations", "true")
+
+        runTasks('dependencies', '--write-locks') // baseline dependency locks
+
+        def actualLocks = new File(projectDir, '/gradle/dependency-locks/').list().toList()
+
+        expectedLocks.each {
+            assert actualLocks.contains(it)
+        }
+        actualLocks.each {
+            assert expectedLocks.contains(it)
+        }
+        def firstRunCompileLockfile = new File(projectDir, '/gradle/dependency-locks/compileClasspath.lockfile')
+        def lockfileContents = """# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+org.clojure:clojure:1.8.0
+test.nebula:a:1.1.0
+test.nebula:b:1.1.0
+"""
+        assert firstRunCompileLockfile.text == lockfileContents
+
+        def firstRunTestCompileLockfile = new File(projectDir, '/gradle/dependency-locks/testCompileClasspath.lockfile')
+        assert firstRunTestCompileLockfile.text == lockfileContents
+    }
+
+    def updateSingleProjectFor(String languagePlugin) {
+        buildFile.delete()
+        buildFile.createNewFile()
+        if (languagePlugin == 'groovy') {
+            buildFile << """\
+            plugins {
+                id 'nebula.dependency-lock'
+                id 'groovy'
+            }
+            
+        """.stripIndent()
+        } else if (languagePlugin == 'java-library') {
+            buildFile << """\
+                plugins {
+                    id 'nebula.dependency-lock'
+                    id 'java-library'
+                }
+                """.stripIndent()
+
+            writeHelloWorld()
+            writeUnitTest()
+        }
+
+        buildFile << """\
+            repositories {
+                ${mavenrepo.mavenRepositoryBlock}
+            }
+            dependencies {
+                compile 'test.nebula:a:1.+'
+                compile 'test.nebula:b:1.+'
+            }
+        """.stripIndent()
+    }
+
+    def tasks(String lockArg, Boolean isMultiProject = false) {
+        def tasks = []
+        isMultiProject ? tasks.add('dependenciesForAll') : tasks.add('dependencies')
+
+        tasks.addAll('--rerun-tasks', '--warning-mode', 'all')
+
+        lockArg == 'write-locks'
+                ? tasks.add("--$lockArg")
+                : tasks.addAll("--$lockArg".toString(), 'test.nebula:d,test.nebula:c,test.nebula:e,has.missing.transitive:a,not.available:a')
+
+        return tasks
+    }
+
+    private String failedResolutionDependencies(String subprojectName = '') {
+        def project = subprojectName != '' ? subprojectName : projectName
+        return """
+  1) Failed to resolve 'not.available:a:1.0.0' for project '$project'
+  2) Failed to resolve 'test.nebula:c' for project '$project'
+  3) Failed to resolve 'test.nebula:e' for project '$project'
+  4) Failed to resolve 'transitive.not.available:a:1.0.0' for project '$project'"""
+    }
+}


### PR DESCRIPTION
Core locking: verify dependency resolution once configurations are resolved; remove only lockfiles that are not requested to be locked

Notes:
1) dependency verification determines if all configurations were resolved correctly and that the lock state is not out of date. Errors in these are collected and cause a build failure with the reasons listed.
2) verification of dependency resolution does not take place when the migrationToCoreLocks task is invoked, as the dependency lock state is not complete enough at that point.
3) when lockfiles are removed, this is logged as a warning and the way to add them to be locked is emitted

Works with parallel builds