### PR TITLE
Introduce skipped configuration names prefixes

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
@@ -19,6 +19,7 @@ class DependencyLockExtension {
     String lockFile = 'dependencies.lock'
     String globalLockFile = 'global.lock'
     Set<String> configurationNames = [] as Set
+    Set<String> skippedConfigurationNamesPrefixes = [] as Set
     Closure dependencyFilter = { String group, String name, String version -> true }
     Set<String> updateDependencies = [] as Set
     Set<String> skippedDependencies = [] as Set

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
@@ -205,6 +205,7 @@ class DependencyLockTaskConfigurer {
                 new File(project.buildDir, clLockFileName ?: extension.lockFile)
             }
             configurationNames = { extension.configurationNames }
+            skippedConfigurationNames = { extension.skippedConfigurationNamesPrefixes }
         }
 
         lockTask
@@ -234,7 +235,7 @@ class DependencyLockTaskConfigurer {
                 def subprojects = project.subprojects.collect { subproject ->
                     def ext = subproject.getExtensions().findByType(DependencyLockExtension)
                     if (ext != null) {
-                        Collection<Configuration> lockableConfigurations = lockableConfigurations(project, subproject, ext.configurationNames)
+                        Collection<Configuration> lockableConfigurations = lockableConfigurations(project, subproject, ext.configurationNames, extension.skippedConfigurationNamesPrefixes)
                         Collection<Configuration> configurations = filterNonLockableConfigurationsAndProvideWarningsForGlobalLockSubproject(subproject, ext.configurationNames, lockableConfigurations)
 
                         configurations
@@ -252,7 +253,7 @@ class DependencyLockTaskConfigurer {
                 def conf = project.configurations.detachedConfiguration(subprojectsArray)
                 project.allprojects.each { it.configurations.add(conf) }
 
-                [conf] + lockableConfigurations(project, project, extension.configurationNames)
+                [conf] + lockableConfigurations(project, project, extension.configurationNames, extension.skippedConfigurationNamesPrefixes)
             }
         }
 

--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
@@ -98,7 +98,7 @@ class GenerateLockTask extends AbstractLockTask {
         Set<Configuration> lockableConfigurations = []
         if (configurationNames.empty) {
             if (Configuration.class.declaredMethods.any { it.name == 'isCanBeResolved' }) {
-                lockableConfigurations = project.configurations.findAll {
+                lockableConfigurations.addAll project.configurations.findAll {
                     if (taskProject == project) {
                         it.canBeResolved && !ConfigurationFilters.safelyHasAResolutionAlternative(it)
                     } else {
@@ -106,10 +106,10 @@ class GenerateLockTask extends AbstractLockTask {
                     }
                 }
             } else {
-                lockableConfigurations = project.configurations.asList()
+                lockableConfigurations.addAll project.configurations.asList()
             }
         } else {
-            lockableConfigurations =  configurationNames.collect { project.configurations.getByName(it) }
+            lockableConfigurations.addAll configurationNames.collect { project.configurations.getByName(it) }
         }
 
         lockableConfigurations.removeAll {

--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
@@ -95,7 +95,7 @@ class GenerateLockTask extends AbstractLockTask {
     }
 
     static Collection<Configuration> lockableConfigurations(Project taskProject, Project project, Set<String> configurationNames, Set<String> skippedConfigurationNamesPrefixes = []) {
-        List<Configuration> lockableConfigurations = []
+        Set<Configuration> lockableConfigurations = []
         if (configurationNames.empty) {
             if (Configuration.class.declaredMethods.any { it.name == 'isCanBeResolved' }) {
                 lockableConfigurations = project.configurations.findAll {


### PR DESCRIPTION
The idea behind `skippedConfigurationNamesPrefixes` is to allow for skipping configs such as `zinc` and `incrementalAnalysis*`.

The reason for this is that Gradle provides `zinc` compiler which work with specific versions of Scala. 

When the `zinc` configuration is locked and gradle upgrades it, which is the case for 5.x to 6.x where they replaced zinc 0.3.x with modern 1.2.x, the scala version does not work anymore and lock files prevent from a smooth upgrade.

```
Caused by: java.lang.NoSuchMethodError: scala.Product.$init$(Lscala/Product;)V
        at scala.xml.NamespaceBinding.<init>(NamespaceBinding.scala:24)
        at scala.xml.TopScope$.<init>(TopScope.scala:17)
        at scala.xml.TopScope$.<clinit>(TopScope.scala)
        at scala.Predef$.<init>(Predef.scala:137)
        at scala.Predef$.<clinit>(Predef.scala)
        at sbt.internal.inc.ScalaInstance.<init>(ScalaInstance.scala:76)
``` 