### PR TITLE
Core lock: ignore extra lockfiles until lock update or regeneration

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
@@ -130,8 +130,12 @@ class CoreLockingHelper {
     }
 
     private void removeLockfilesForUnlockedConfigurations() {
-        def migrationTaskWasRequested = project.gradle.startParameter.taskNames.contains(DependencyLockTaskConfigurer.MIGRATE_TO_CORE_LOCKS_TASK_NAME)
-        if (!shouldLockAllConfigurations && !migrationTaskWasRequested) {
+        boolean migrationTaskWasRequested = project.gradle.startParameter.taskNames.contains(DependencyLockTaskConfigurer.MIGRATE_TO_CORE_LOCKS_TASK_NAME)
+        boolean hasWriteLocksFlag = project.gradle.startParameter.isWriteDependencyLocks()
+        boolean hasDependenciesToUpdate = !project.gradle.startParameter.getLockedDependenciesToUpdate().isEmpty()
+        boolean isUpdatingDependencies = hasWriteLocksFlag || hasDependenciesToUpdate
+
+        if (!shouldLockAllConfigurations && !migrationTaskWasRequested && isUpdatingDependencies) {
             project.gradle.taskGraph.whenReady { taskGraph ->
                 LinkedList tasks = taskGraph.executionPlan.executionQueue
                 Task lastTask = tasks.last?.task

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
@@ -749,7 +749,7 @@ class DependencyLockPluginWithCoreSpec extends AbstractDependencyLockPluginSpec 
         !cleanBuildResults.output.contains('FAILURE')
     }
 
-    def 'generate core lock should lock delete stale lockfiles when regenerating'() {
+    def 'generate core lock should ignore extra lockfiles and then delete stale lockfiles when regenerating'() {
         given:
         buildFile.text = """\
             plugins {
@@ -787,6 +787,15 @@ class DependencyLockPluginWithCoreSpec extends AbstractDependencyLockPluginSpec 
         lockFile.exists()
 
         when:
+        def buildResult = runTasks('clean', 'build')
+
+        then:
+        !buildResult.output.contains('FAIL')
+
+        def customConfigurationLockFile = new File(projectDir, '/gradle/dependency-locks/customConfiguration.lockfile')
+        assert customConfigurationLockFile.exists()
+
+        when:
         runTasks('dependencies', '--write-locks')
 
         then:
@@ -798,11 +807,11 @@ class DependencyLockPluginWithCoreSpec extends AbstractDependencyLockPluginSpec 
             assert expectedLocks.contains(actual)
         }
 
-        def customConfigurationLockFile = new File(projectDir, '/gradle/dependency-locks/customConfiguration.lockfile')
-        assert !customConfigurationLockFile.exists()
+        def customConfigurationLockFileAfterWriteLocks = new File(projectDir, '/gradle/dependency-locks/customConfiguration.lockfile')
+        assert !customConfigurationLockFileAfterWriteLocks.exists()
     }
 
-    def 'generate core lock should lock delete stale lockfiles when regenerating - multiproject setup'() {
+    def 'generate core lock should ignore extra lockfiles and then delete stale lockfiles when regenerating - multiproject setup'() {
         given:
         definePluginOutsideOfPluginBlock = true
         buildFile.text = """\
@@ -855,6 +864,15 @@ class DependencyLockPluginWithCoreSpec extends AbstractDependencyLockPluginSpec 
         lockFile.exists()
 
         when:
+        def buildResult = runTasks('clean', 'build')
+
+        then:
+        !buildResult.output.contains('FAIL')
+
+        def customConfigurationLockFile = new File(projectDir, 'sub1/gradle/dependency-locks/customConfiguration.lockfile')
+        assert customConfigurationLockFile.exists()
+
+        when:
         runTasks('dependenciesForAll', '--write-locks')
 
         then:
@@ -866,8 +884,8 @@ class DependencyLockPluginWithCoreSpec extends AbstractDependencyLockPluginSpec 
             assert expectedLocks.contains(actual)
         }
 
-        def customConfigurationLockFile = new File(projectDir, 'sub1/gradle/dependency-locks/customConfiguration.lockfile')
-        assert !customConfigurationLockFile.exists()
+        def customConfigurationLockFileAfterWriteLocks = new File(projectDir, 'sub1/gradle/dependency-locks/customConfiguration.lockfile')
+        assert !customConfigurationLockFileAfterWriteLocks.exists()
     }
 
     @Unroll


### PR DESCRIPTION
This will help folks who will be locking fewer configurations. When a plugin update is applied, they can still run build processes without file changes until they are ready to update dependencies.