### PR TITLE
Improve error message from DependencyResolutionVerifier

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifier.groovy
+++ b/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifier.groovy
@@ -133,6 +133,7 @@ class DependencyResolutionVerifier {
                             if (failedDepsByConf.size() != 0 || lockedDepsOutOfDate.size() != 0) {
                                 List<String> message = new ArrayList<>()
                                 List<String> debugMessage = new ArrayList<>()
+                                List<String> depsMissingVersions = new ArrayList<>()
                                 try {
                                     if (failedDepsByConf.size() > 0) {
                                         message.add("Failed to resolve the following dependencies:")
@@ -149,6 +150,9 @@ class DependencyResolutionVerifier {
                                                         .each { failedConf ->
                                                             debugMessage.add("  - $failedConf")
                                                         }
+                                                if (dep.split(':').size() < 3) {
+                                                    depsMissingVersions.add(dep)
+                                                }
                                             }
 
                                     if (lockedDepsOutOfDate.size() > 0) {
@@ -159,6 +163,11 @@ class DependencyResolutionVerifier {
                                             .eachWithIndex { outOfDateMessage, index ->
                                                 message.add("  ${index + 1}. $outOfDateMessage for project '${project.name}'")
                                             }
+
+                                    if (depsMissingVersions.size() > 0) {
+                                        message.add("The following dependencies are missing a version: ${depsMissingVersions.join(', ')}\n" +
+                                                "Please add a version to fix this. If you have been using a BOM, perhaps these dependencies are no longer managed.")
+                                    }
 
                                 } catch (Exception e) {
                                     throw new BuildCancelledException("Error creating message regarding failed dependencies", e)

--- a/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
+++ b/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
@@ -125,6 +125,7 @@ class DependencyResolutionVerifierTest extends IntegrationTestKitSpec {
         buildFile << """
             dependencies {
                 implementation 'test.nebula:c' // version is missing
+                implementation 'test.nebula:d' // version is missing
             }
             """.stripIndent()
 
@@ -136,6 +137,9 @@ class DependencyResolutionVerifierTest extends IntegrationTestKitSpec {
         results.output.contains('Execution failed for task')
         results.output.contains('> Failed to resolve the following dependencies:')
         results.output.contains("1. Failed to resolve 'test.nebula:c' for project")
+        results.output.contains("2. Failed to resolve 'test.nebula:d' for project")
+        results.output.contains("The following dependencies are missing a version: test.nebula:c, test.nebula:d")
+        results.output.contains("If you have been using a BOM")
 
         where:
         tasks                                         | description


### PR DESCRIPTION
Improve error message from DependencyResolutionVerifier for dependencies missing a version by adding a message at the end:

```
The following dependencies are missing a version: group1:artifact1, group2:artifact2
Please add a version to fix this. If you have been using a BOM, perhaps these dependencies are no longer managed
```