### PR TITLE
add extra configurations for configurationsToSkipForGlobalLock

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
@@ -57,7 +57,7 @@ class DependencyLockTaskConfigurer {
     public static final String SAVE_LOCK_TASK_NAME = 'saveLock'
     public static final String SAVE_GLOBAL_LOCK_TASK_NAME = 'saveGlobalLock'
 
-    final Set<String> configurationsToSkipForGlobalLock = ['checkstyle', 'findbugs', 'findbugsPlugins', 'jacocoAgent', 'jacocoAnt']
+    final Set<String> configurationsToSkipForGlobalLock = ['checkstyle', 'findbugs', 'findbugsPlugins', 'jacocoAgent', 'jacocoAnt', 'spotbugs', 'spotbugsPlugins', 'zinc']
 
     Project project
 


### PR DESCRIPTION
adds spotbugs and scala plugin to the ignored configurations for global lock.

This prevents leaking dependencies from this plugins.

 this is a quick fix Since we don't support global locks anymore. Ideally it should only lock configurations that matter