### PR TITLE
default configuration is not resolvable anymore

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions-snapshots/gradle-6.3-20200310000020+0000-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.3-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.2-bin.zip
+distributionUrl=https://services.gradle.org/distributions-snapshots/gradle-6.3-20200310000020+0000-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/ConfigurationsToLockFinder.groovy
@@ -45,7 +45,6 @@ class ConfigurationsToLockFinder {
         def baseConfigurations = [
                 'annotationProcessor',
                 'compileClasspath',
-                'default',
                 'runtimeClasspath'
         ]
         baseConfigurations.addAll(additionalBaseConfigurationsToLock)

--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
@@ -101,7 +101,8 @@ class GenerateLockTask extends AbstractLockTask {
                     if (taskProject == project) {
                         it.canBeResolved && !ConfigurationFilters.safelyHasAResolutionAlternative(it)
                     } else {
-                        it.canBeResolved && it.canBeConsumed && !ConfigurationFilters.safelyHasAResolutionAlternative(it)
+                        //TODO: we need a better approach for global locks because `default` is going away
+                        it.canBeResolved && it.canBeConsumed && (!ConfigurationFilters.safelyHasAResolutionAlternative(it) || it.name == 'default')
                     }
                 }
             } else {

--- a/src/test/groovy/nebula/plugin/dependencylock/AbstractDependencyLockPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/AbstractDependencyLockPluginSpec.groovy
@@ -26,7 +26,6 @@ class AbstractDependencyLockPluginSpec extends IntegrationTestKitSpec {
             : [
             'annotationProcessor.lockfile',
             'compileClasspath.lockfile',
-            'default.lockfile',
             'runtimeClasspath.lockfile',
             'testAnnotationProcessor.lockfile',
             'testCompileClasspath.lockfile',

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
@@ -866,10 +866,9 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
     def 'uses chosen subproject configurations when creating global lock in multiproject'() {
         addSubproject('sub1', """\
             configurations {
-                special
+                special 
             }
             dependencies {
-                implementation 'test.example:bar:1.1.0'
                 special 'test.example:foo:2.0.0'
             }
             dependencyLock.configurationNames = ['runtimeElements', 'apiElements', 'special']
@@ -884,6 +883,7 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
                 apply plugin: 'java'
                 repositories { maven { url '${Fixture.repo}' } }
             }
+            
             dependencyLock {
                 includeTransitives = true
             }
@@ -896,16 +896,9 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
         String globalLockText = '''\
             {
                 "_global_": {
-                    "test.example:bar": {
-                        "locked": "1.1.0",
-                        "transitive": [
-                            "test:sub1"
-                        ]
-                    },
                     "test.example:foo": {
                         "locked": "2.0.0",
                         "transitive": [
-                            "test.example:bar",
                             "test:sub1"
                         ]
                     },

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
@@ -872,7 +872,7 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
                 implementation 'test.example:bar:1.1.0'
                 special 'test.example:foo:2.0.0'
             }
-            dependencyLock.configurationNames = ['default', 'runtimeElements', 'apiElements', 'special']
+            dependencyLock.configurationNames = ['runtimeElements', 'apiElements', 'special']
         """.stripIndent())
 
         buildFile << """\
@@ -1329,7 +1329,7 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
         "test:sub4": {
             "project": true
         }
-        '''.stripIndent(), ['default', 'runtimeClasspath', 'testRuntimeClasspath'], '''\
+        '''.stripIndent(), ['runtimeClasspath', 'testRuntimeClasspath'], '''\
         "test:sub4": {
             "project": true
         }
@@ -1361,7 +1361,7 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
         "test:sub4": {
             "project": true
         }
-        '''.stripIndent(), ['default', 'runtimeClasspath', 'testRuntimeClasspath'], '''\
+        '''.stripIndent(), ['runtimeClasspath', 'testRuntimeClasspath'], '''\
         "test:sub4": {
             "project": true
         }

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
@@ -190,10 +190,10 @@ class DependencyLockPluginWithCoreSpec extends AbstractDependencyLockPluginSpec 
         def results = runTasks('dependencies')
 
         then:
-        results.output.contains('test.nebula:a:1.+ -> 1.1.0')
+        results.output.contains('test.nebula:a:1.+ -> 1.0.0')
         results.output.contains('test.nebula:a:{strictly 1.0.0} -> 1.0.0 ')
 
-        results.output.contains('test.nebula:b:1.+ -> 1.1.0')
+        results.output.contains('test.nebula:b:1.+ -> 1.0.0')
         results.output.contains('test.nebula:b:{strictly 1.0.0} -> 1.0.0 ')
     }
 
@@ -226,7 +226,7 @@ class DependencyLockPluginWithCoreSpec extends AbstractDependencyLockPluginSpec 
             assert actualLocks.contains(it): "There is a missing lockfile: $it"
         }
         assert actualLocks.size() > expectedLocks.size()
-        def allExpectedLocks = ["archives.lockfile", "testCompileClasspath.lockfile",
+        def allExpectedLocks = ["testCompileClasspath.lockfile",
                                 "annotationProcessor.lockfile",
                                 "compileClasspath.lockfile", "jacocoAnt.lockfile", "testAnnotationProcessor.lockfile",
                                 "jacocoAgent.lockfile", "testRuntimeClasspath.lockfile",

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
@@ -228,8 +228,7 @@ class DependencyLockPluginWithCoreSpec extends AbstractDependencyLockPluginSpec 
         assert actualLocks.size() > expectedLocks.size()
         def allExpectedLocks = ["archives.lockfile", "testCompileClasspath.lockfile",
                                 "annotationProcessor.lockfile",
-                                "compileClasspath.lockfile", "jacocoAnt.lockfile",
-                                "default.lockfile", "testAnnotationProcessor.lockfile",
+                                "compileClasspath.lockfile", "jacocoAnt.lockfile", "testAnnotationProcessor.lockfile",
                                 "jacocoAgent.lockfile", "testRuntimeClasspath.lockfile",
                                 "runtimeClasspath.lockfile"]
         allExpectedLocks.each {

--- a/src/test/groovy/nebula/plugin/dependencylock/tasks/DiffLockTaskSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/tasks/DiffLockTaskSpec.groovy
@@ -224,7 +224,7 @@ class DiffLockTaskSpec extends ProjectSpec {
                     "locked": "1.1.0",
                     "requested": "1.+"
                 }
-                '''.stripIndent(), ['compileClasspath', 'default', 'runtimeClasspath'],
+                '''.stripIndent(), ['compileClasspath', 'runtimeClasspath'],
                 '''\
                 "test.nebula:a": {
                     "locked": "1.1.1",
@@ -245,7 +245,7 @@ class DiffLockTaskSpec extends ProjectSpec {
         String expected = '''\
             inconsistent:
               test.nebula:a:
-                1.0.0 -> 1.1.0 [compileClasspath,default,runtimeClasspath]
+                1.0.0 -> 1.1.0 [compileClasspath,runtimeClasspath]
                 1.0.0 -> 1.1.1 [testCompileClasspath,testRuntimeClasspath]
             '''.stripIndent()
         realizedTask.diffFile.text == expected

--- a/src/test/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTaskSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTaskSpec.groovy
@@ -72,7 +72,7 @@ class GenerateLockTaskSpec extends ProjectSpec {
         task.dependenciesLock = new File(project.buildDir, 'dependencies.lock')
         task.configurationNames = project.configurations
                 .stream()
-                .filter { it.isCanBeResolved() }
+                .filter { it.isCanBeResolved() && (it?.getResolutionAlternatives()?.isEmpty() || !it?.getResolutionAlternatives()) }
                 .collect { it.name }
                 .toSet()
 
@@ -107,7 +107,7 @@ class GenerateLockTaskSpec extends ProjectSpec {
         task.dependenciesLock = new File(project.buildDir, 'dependencies.lock')
         task.configurationNames = project.configurations
                 .stream()
-                .filter { it.isCanBeResolved() }
+                .filter { it.isCanBeResolved() && (it?.getResolutionAlternatives()?.isEmpty() || !it?.getResolutionAlternatives()) }
                 .collect { it.name }
                 .toSet()
         task.skippedConfigurationNames = ['zinc', 'incrementalAnalysis']

--- a/src/test/groovy/nebula/plugin/dependencylock/util/LockGenerator.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/util/LockGenerator.groovy
@@ -20,9 +20,9 @@ import nebula.plugin.dependencylock.utils.GradleVersionUtils
 class LockGenerator {
     static final Collection<String> DEFAULT_CONFIG_NAMES = GradleVersionUtils.currentGradleVersionIsLessThan("6.0")
             ? ['compile', 'compileClasspath', 'default', 'runtime', 'runtimeClasspath', 'testCompile', 'testCompileClasspath', 'testRuntime', 'testRuntimeClasspath']
-            : ['compileClasspath', 'default', 'runtimeClasspath', 'testCompileClasspath', 'testRuntimeClasspath']
+            : ['compileClasspath', 'runtimeClasspath', 'testCompileClasspath', 'testRuntimeClasspath']
     static final Collection<String> DEFAULT_CONFIG_NAMES_POPULATED_BY_IMPLEMENTATION_SCOPE =
-            ['compileClasspath', 'default', 'runtimeClasspath', 'testCompileClasspath', 'testRuntimeClasspath']
+            ['compileClasspath', 'runtimeClasspath', 'testCompileClasspath', 'testRuntimeClasspath']
 
     /**
      * Helper to copy the exact same lock block multiple times into different configurations

--- a/src/test/groovy/nebula/plugin/dependencylock/utils/ConfigurationFiltersProjectSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/utils/ConfigurationFiltersProjectSpec.groovy
@@ -27,7 +27,7 @@ class ConfigurationFiltersProjectSpec extends ProjectSpec {
         project.apply plugin: 'java-library'
     }
 
-    def "compile, compileOnly, runtime, testCompile, testCompileOnly, and testRuntime should not be resolved after Gradle 6.0"() {
+    def "archives, default, compile, compileOnly, runtime, testCompile, testCompileOnly, and testRuntime should not be resolved after Gradle 6.2"() {
         when:
         def results = project
                 .configurations
@@ -43,10 +43,14 @@ class ConfigurationFiltersProjectSpec extends ProjectSpec {
         then:
         if (GradleVersionUtils.currentGradleVersionIsLessThan('6.0')) {
             assert results.size() == 0
-        } else {
+        } else if (GradleVersionUtils.currentGradleVersionIsLessThan('6.3')) {
             assert results.size() == 6
+        } else {
+            assert results.size() == 8
 
             Collection<String> configurationNames = results.collect { (it as Configuration).name }
+            assert configurationNames.contains('default')
+            assert configurationNames.contains('archives')
             assert configurationNames.contains('compile')
             assert configurationNames.contains('compileOnly')
             assert configurationNames.contains('runtime')
@@ -56,7 +60,7 @@ class ConfigurationFiltersProjectSpec extends ProjectSpec {
         }
     }
 
-    def "facets with similar configurations should not be resolved after Gradle 6.0"() {
+    def "facets with similar configurations should not be resolved after Gradle 6.2"() {
         given:
         project.apply plugin: NebulaIntegTestPlugin.class
         project.facets {
@@ -80,10 +84,14 @@ class ConfigurationFiltersProjectSpec extends ProjectSpec {
         then:
         if (GradleVersionUtils.currentGradleVersionIsLessThan('6.0')) {
             assert results.size() == 0
-        } else {
+        }  else if (GradleVersionUtils.currentGradleVersionIsLessThan('6.3')) {
             assert results.size() == 9
+        } else {
+            assert results.size() == 11
 
             Collection<String> configurationNames = results.collect { (it as Configuration).name }
+            assert configurationNames.contains('default')
+            assert configurationNames.contains('archives')
             assert configurationNames.contains('compile')
             assert configurationNames.contains('compileOnly')
             assert configurationNames.contains('runtime')


### PR DESCRIPTION
Part of the work Gradle folks did when we detected the issue with the tooling API metadata is deprecating the `default` configuration which is not resolvable anymore

Here is the PR that addresses that and will be part of Gradle 6.3: https://github.com/gradle/gradle/pull/12460/files

This PR uses a snapshot to make sure things work but I'll update it once RC and/or final comes out
