### PR TITLE
Remove 'requested' field from lock files

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockWriter.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockWriter.groovy
@@ -43,9 +43,6 @@ class DependencyLockWriter {
             } else {
                 depMap['project'] = true
             }
-            if (lock.requested) {
-                depMap['requested'] = lock.requested
-            }
             if (lock.viaOverride) {
                 depMap['viaOverride'] = lock.viaOverride
             }

--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
@@ -188,16 +188,6 @@ class GenerateLockTask extends AbstractLockTask {
             def peers = project.rootProject.allprojects.collect { new LockKey(group: it.group, artifact: it.name) }
 
             confs.each { Configuration configuration ->
-                // Capture the version of each dependency as requested in the build script for reference.
-                def externalDependencies = configuration.allDependencies.withType(ExternalDependency)
-                def filteredExternalDependencies = externalDependencies.findAll { Dependency dependency ->
-                    filter(dependency.group, dependency.name, dependency.version)
-                }
-                filteredExternalDependencies.each { ExternalDependency dependency ->
-                    def key = new LockKey(group: dependency.group, artifact: dependency.name, configuration: configuration.name)
-                    deps[key].requested = dependency.version
-                }
-
                 // Lock the version of each dependency specified in the build script as resolved by Gradle.
                 def resolvedDependencies = configuration.resolvedConfiguration.firstLevelModuleDependencies
                 def filteredResolvedDependencies = resolvedDependencies.findAll { ResolvedDependency resolved ->

--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/MigrateLockedDepsToCoreLocksTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/MigrateLockedDepsToCoreLocksTask.groovy
@@ -24,9 +24,7 @@ import nebula.plugin.dependencylock.utils.CoreLockingHelper
 import org.gradle.api.BuildCancelledException
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
-import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 
 class MigrateLockedDepsToCoreLocksTask extends AbstractMigrateToCoreLocksTask {
@@ -57,7 +55,7 @@ class MigrateLockedDepsToCoreLocksTask extends AbstractMigrateToCoreLocksTask {
 
                 def migrateConfigurationClosure = {
                     def dependenciesForConf = new ArrayList()
-                    def locks = lockReader.readLocks(it, getInputLockFile())
+                    def locks = lockReader.readLocks(it, getInputLockFile(), new HashMap<>())
 
                     if (locks != null) {
                         for (Map.Entry<String, ArrayList<String>> entry : locks.entrySet()) {

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
@@ -63,8 +63,7 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
         {
             "compileClasspath": {
                 "test.example:foo": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 }
             }
         }
@@ -72,40 +71,35 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
 
     static final String DEPRECATED_LOCK_FORMAT = '''\
         {
-           "test.example:foo": { "locked": "1.0.0", "requested": "1.+" }
+           "test.example:foo": { "locked": "1.0.0" }
         }
     '''.stripIndent()
 
     static final String PRE_DIFF_FOO_LOCK = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly('''\
                 "test.example:foo": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 }
                 '''.stripIndent())
 
     static final String FOO_LOCK = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly('''\
                 "test.example:foo": {
-                    "locked": "1.0.1",
-                    "requested": "1.+"
+                    "locked": "1.0.1"
                 }
                 '''.stripIndent())
 
     static final String NEW_FOO_LOCK = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly('''\
                 "test.example:foo": {
                     "locked": "2.0.1",
-                    "requested": "1.+",
                     "viaOverride": "2.0.1"
                 }
                 '''.stripIndent())
 
     static final String REMOVE_UPDATE_LOCK = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly('''\
                 "test.example:baz": {
-                    "locked": "1.1.0",
-                    "requested": "1.+"
+                    "locked": "1.1.0"
                 },
                 "test.example:foo": {
-                    "locked": "1.0.1",
-                    "requested": "1.+"
+                    "locked": "1.0.1"
                 }
                 '''.stripIndent())
 
@@ -396,8 +390,7 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
 
         def lockWithSkips = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly('''\
                 "test.example:baz": {
-                    "locked": "1.1.0",
-                    "requested": "1.+"
+                    "locked": "1.1.0"
                 }
             '''.stripIndent())
 
@@ -624,7 +617,6 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
         String lockText1 = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly('''\
                 "test.example:foo": {
                     "locked": "2.0.0",
-                    "requested": "2.+",
                     "viaOverride": "2.0.0"
                 }
             '''.stripIndent())
@@ -632,7 +624,6 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
         String lockText2 = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly('''\
                 "test.example:baz": {
                     "locked": "1.0.0",
-                    "requested": "1.+",
                     "viaOverride": "1.0.0"
                 }
             '''.stripIndent())
@@ -975,15 +966,13 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
         new File(projectDir, 'dependencies.lock').text.replaceAll(' ', '') == lockText
         String lockText1 = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly('''\
                 "test.example:foo": {
-                    "locked": "2.0.0",
-                    "requested": "2.0.0"
+                    "locked": "2.0.0"
                 }
             '''.stripIndent())
         new File(projectDir, 'sub1/dependencies.lock').text == lockText1
         String lockText2 = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly('''\
                 "test.example:foo": {
-                    "locked": "1.0.1",
-                    "requested": "1.+"
+                    "locked": "1.0.1"
                 }
             '''.stripIndent())
         new File(projectDir, 'sub2/dependencies.lock').text == lockText2
@@ -994,15 +983,13 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
         new File(projectDir, 'dependencies.lock').text = '{}'
         new File(projectDir, 'sub1/dependencies.lock').text = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly('''\
                 "test.example:foo": {
-                    "locked": "2.0.0",
-                    "requested": "2.0.0"
+                    "locked": "2.0.0"
                 }
             '''.stripIndent())
 
         new File(projectDir, 'sub2/dependencies.lock').text = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly('''\
                 "test.example:foo": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 }
             '''.stripIndent())
 
@@ -1150,12 +1137,10 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
         def lockText = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly(
                 '''\
                     "test.example:bar": {
-                        "locked": "1.0.0",
-                        "requested": "1.+"
+                        "locked": "1.0.0"
                     },
                     "test.example:qux": {
-                        "locked": "1.0.0",
-                        "requested": "latest.release"
+                        "locked": "1.0.0"
                     },
                     "test.example:foo": {
                         "locked": "1.0.0",
@@ -1170,8 +1155,7 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
         def updatedLock = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly(
                 '''\
                     "test.example:bar": {
-                        "locked": "1.1.0",
-                        "requested": "1.+"
+                        "locked": "1.1.0"
                     },
                     "test.example:foo": {
                         "locked": "1.0.1",
@@ -1181,8 +1165,7 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
                         ]
                     },
                     "test.example:qux": {
-                        "locked": "1.0.0",
-                        "requested": "latest.release"
+                        "locked": "1.0.0"
                     }'''.stripIndent()
         )
 
@@ -1221,8 +1204,7 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
                         "locked": "1.0.0"
                     },
                     "test.example:qux": {
-                        "locked": "1.0.0",
-                        "requested": "latest.release"
+                        "locked": "1.0.0"
                     },
                     "test.example:foo": {
                         "locked": "1.0.0",
@@ -1247,8 +1229,7 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
                         ]
                     },
                     "test.example:qux": {
-                        "locked": "2.0.0",
-                        "requested": "latest.release"
+                        "locked": "2.0.0"
                     }'''.stripIndent()
         )
 
@@ -1701,8 +1682,7 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
                 ]
             },
             "test.nebula:foo": {
-                "locked": "1.0.0",
-                "requested": "1.+"
+                "locked": "1.0.0"
             }
             '''.stripIndent())
 
@@ -1837,8 +1817,7 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
         def deplock = new File(projectDir, 'dependencies.lock')
         deplock.text = LockGenerator.duplicateIntoConfigs('''\
             "test.nebula:foo": {
-                "locked": "1.0.0",
-                "requested": "1.+"
+                "locked": "1.0.0"
             }
             '''.stripIndent())
 
@@ -1873,12 +1852,10 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
         def deplock = new File(projectDir, 'dependencies.lock')
         deplock.text = LockGenerator.duplicateIntoConfigs('''\
             "test.nebula:bar": {
-                "locked": "1.0.0",
-                "requested": "1.+"
+                "locked": "1.0.0"
             },
             "test.nebula:foo": {
-                "locked": "1.0.0",
-                "requested": "1.+"
+                "locked": "1.0.0"
             }
             '''.stripIndent())
 

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginSpec.groovy
@@ -210,12 +210,10 @@ class DependencyLockPluginSpec extends ProjectSpec {
             {
                 "compileClasspath": {
                     "test.example:foo": {
-                        "locked": "1.0.0",
-                        "requested": "1.+"
+                        "locked": "1.0.0"
                     },
                     "test.example:baz": {
-                        "locked": "2.0.0",
-                        "requested": "2.+"
+                        "locked": "2.0.0"
                     }
                 }
             }
@@ -340,14 +338,12 @@ class DependencyLockPluginSpec extends ProjectSpec {
             {
                 "compileClasspath": {
                     "test.example:baz": {
-                        "locked": "1.0.0",
-                        "requested": "1.+"
+                        "locked": "1.0.0"
                     }
                 },
                 "runtimeClasspath": {
                     "test.example:baz": {
-                        "locked": "1.0.0",
-                        "requested": "1.+"
+                        "locked": "1.0.0"
                     }
                 }
             }
@@ -361,8 +357,7 @@ class DependencyLockPluginSpec extends ProjectSpec {
             {
                 "compileClasspath": {
                     "test.example:foo": {
-                        "locked": "2.0.0",
-                        "requested": "2.+"
+                        "locked": "2.0.0"
                     },
                     "test.nebula:sub1": {
                         "project": true,
@@ -375,8 +370,7 @@ class DependencyLockPluginSpec extends ProjectSpec {
                         "firstLevelTransitive": [ "test.nebula:sub1" ]
                     },
                     "test.example:foo": {
-                        "locked": "2.0.0",
-                        "requested": "2.+"
+                        "locked": "2.0.0"
                     },
                     "test.nebula:sub1": {
                         "project": true,
@@ -423,8 +417,7 @@ class DependencyLockPluginSpec extends ProjectSpec {
             {
                 "_global_": {
                     "test.example:foo": {
-                        "locked": "1.0.1",
-                        "requested": "1.+"
+                        "locked": "1.0.1"
                     }
                 }
             }
@@ -457,8 +450,7 @@ class DependencyLockPluginSpec extends ProjectSpec {
             {
                 "compileClasspath": {
                     "test.example:foo": {
-                        "locked": "1.0.0",
-                        "requested": "1.+"
+                        "locked": "1.0.0"
                     }
                 }
             }
@@ -472,8 +464,7 @@ class DependencyLockPluginSpec extends ProjectSpec {
             {
                 "compileClasspath": {
                     "test.example:foo": {
-                        "locked": "2.0.0",
-                        "requested": "2.+"
+                        "locked": "2.0.0"
                     }
                 }
             }
@@ -508,14 +499,12 @@ class DependencyLockPluginSpec extends ProjectSpec {
             {
                 "compileClasspath": {
                     "test.example:foo": {
-                        "locked": "1.0.0",
-                        "requested": "1.+"
+                        "locked": "1.0.0"
                     }
                 },
                 "default": {
                     "test.example:foo": {
-                        "locked": "1.0.0",
-                        "requested": "1.+"
+                        "locked": "1.0.0"
                     }
                 }
             }

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
@@ -1111,12 +1111,10 @@ class DependencyLockPluginWithCoreSpec extends AbstractDependencyLockPluginSpec 
         legacyLockFile.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 },
                 "test.nebula:b": {
-                    "locked": "1.1.0",
-                    "requested": "1.+"
+                    "locked": "1.1.0"
                 }'''.stripIndent())
 
         when:

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockReaderSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockReaderSpec.groovy
@@ -17,15 +17,14 @@ class DependencyLockReaderSpec extends ProjectSpec {
                         ]
                     },
                     "mytest:foobar": {
-                        "locked": "1.6.5",
-                        "requested": "1.+"
+                        "locked": "1.6.5"
                     }
                 }
             }
             '''.stripIndent()
 
         when:
-        reader.readLocks(project.configurations.compileClasspath, globalLock, ['test:baz'])
+        reader.readLocks(project.configurations.compileClasspath, globalLock, new HashMap<>(), ['test:baz'])
 
         then:
         noExceptionThrown()

--- a/src/test/groovy/nebula/plugin/dependencylock/tasks/DiffLockTaskSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/tasks/DiffLockTaskSpec.groovy
@@ -11,8 +11,7 @@ class DiffLockTaskSpec extends ProjectSpec {
         existingLock.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 }
                 '''.stripIndent())
 
@@ -22,8 +21,7 @@ class DiffLockTaskSpec extends ProjectSpec {
         newLock.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.1.0",
-                    "requested": "1.+"
+                    "locked": "1.1.0"
                 }
                 '''.stripIndent())
         def task = project.tasks.register("diffLock", DiffLockTask)
@@ -57,8 +55,7 @@ class DiffLockTaskSpec extends ProjectSpec {
         newLock.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 }
                 '''.stripIndent())
         def task = project.tasks.register("diffLock", DiffLockTask)
@@ -89,8 +86,7 @@ class DiffLockTaskSpec extends ProjectSpec {
         newLock.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 }
                 '''.stripIndent())
         def task = project.tasks.register("diffLock", DiffLockTask)
@@ -116,8 +112,7 @@ class DiffLockTaskSpec extends ProjectSpec {
         existingLock.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 }
                 '''.stripIndent())
 
@@ -150,18 +145,15 @@ class DiffLockTaskSpec extends ProjectSpec {
         existingLock.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 }
                 '''.stripIndent(), ['compile', 'compileClasspath', 'default', 'runtime', 'runtimeClasspath'],
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 },
                 "test.nebula:testlib": {
-                    "locked": "2.0.0",
-                    "requested": "2.+"
+                    "locked": "2.0.0"
                 }
                 '''.stripIndent(), ['testCompile', 'testCompileClasspath', 'testRuntime', 'testRuntimeClasspath'])
 
@@ -171,18 +163,15 @@ class DiffLockTaskSpec extends ProjectSpec {
         newLock.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.1.0",
-                    "requested": "1.+"
+                    "locked": "1.1.0"
                 }
                 '''.stripIndent(), ['compile', 'compileClasspath', 'default', 'runtime', 'runtimeClasspath'],
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.1.0",
-                    "requested": "1.+"
+                    "locked": "1.1.0"
                 },
                 "test.nebula:testlib": {
-                    "locked": "2.0.2",
-                    "requested": "2.+"
+                    "locked": "2.0.2"
                 }
                 '''.stripIndent(), ['testCompile', 'testCompileClasspath', 'testRuntime', 'testRuntimeClasspath'])
         def task = project.tasks.register("diffLock", DiffLockTask)
@@ -210,8 +199,7 @@ class DiffLockTaskSpec extends ProjectSpec {
         existingLock.text = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 }
                 '''.stripIndent())
 
@@ -221,14 +209,12 @@ class DiffLockTaskSpec extends ProjectSpec {
         newLock.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.1.0",
-                    "requested": "1.+"
+                    "locked": "1.1.0"
                 }
                 '''.stripIndent(), ['compileClasspath', 'runtimeClasspath'],
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.1.1",
-                    "requested": "1.+"
+                    "locked": "1.1.1"
                 }
                 '''.stripIndent(), ['testCompileClasspath', 'testRuntimeClasspath'])
         def task = project.tasks.register("diffLock", DiffLockTask)

--- a/src/test/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTaskSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTaskSpec.groovy
@@ -48,12 +48,10 @@ class GenerateLockTaskSpec extends ProjectSpec {
             {
                 "testRuntimeClasspath": {
                     "test.example:baz": {
-                        "locked": "1.1.0",
-                        "requested": "1.+"
+                        "locked": "1.1.0"
                     },
                     "test.example:foo": {
-                        "locked": "2.0.1",
-                        "requested": "2.+"
+                        "locked": "2.0.1"
                     }
                 }
             }'''.stripIndent()
@@ -83,8 +81,7 @@ class GenerateLockTaskSpec extends ProjectSpec {
         String lockText = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly(
                 '''\
                     "test.example:foo": {
-                        "locked": "2.0.1",
-                        "requested": "2.+"
+                        "locked": "2.0.1"
                     }'''.stripIndent())
         task.dependenciesLock.text == lockText
     }
@@ -119,8 +116,7 @@ class GenerateLockTaskSpec extends ProjectSpec {
         String lockText = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly(
                 '''\
                     "test.example:foo": {
-                        "locked": "2.0.1",
-                        "requested": "2.+"
+                        "locked": "2.0.1"
                     }'''.stripIndent())
         task.dependenciesLock.text == lockText
         !task.dependenciesLock.text.contains('"zinc"')
@@ -150,8 +146,7 @@ class GenerateLockTaskSpec extends ProjectSpec {
                         ]
                     },
                     "test.example:foobaz": {
-                        "locked": "1.0.0",
-                        "requested": "1.+"
+                        "locked": "1.0.0"
                     }
                 }
             }'''.stripIndent()
@@ -192,8 +187,7 @@ class GenerateLockTaskSpec extends ProjectSpec {
             {
                 "testRuntimeClasspath": {
                     "test.example:foo": {
-                        "locked": "2.0.1",
-                        "requested": "2.+"
+                        "locked": "2.0.1"
                     },
                     "test.nebula:common": {
                         "project": true
@@ -412,8 +406,7 @@ class GenerateLockTaskSpec extends ProjectSpec {
             {
                 "testRuntimeClasspath": {
                     "test.example:bar": {
-                        "locked": "1.1.0",
-                        "requested": "1.+"
+                        "locked": "1.1.0"
                     },
                     "test.example:foo": {
                         "locked": "1.0.1",
@@ -448,7 +441,6 @@ class GenerateLockTaskSpec extends ProjectSpec {
                 "testRuntimeClasspath": {
                     "circular:a": {
                         "locked": "1.0.0",
-                        "requested": "1.+",
                         "transitive": [
                             "circular:b"
                         ]
@@ -498,8 +490,7 @@ class GenerateLockTaskSpec extends ProjectSpec {
                         ]
                     },
                     "circular:oneleveldeep": {
-                        "locked": "1.0.0",
-                        "requested": "1.+"
+                        "locked": "1.0.0"
                     }
                 }
             }'''.stripIndent()
@@ -528,8 +519,7 @@ class GenerateLockTaskSpec extends ProjectSpec {
             {
                 "testRuntimeClasspath": {
                     "test.example:bar": {
-                        "locked": "1.1.0",
-                        "requested": "1.+"
+                        "locked": "1.1.0"
                     },
                     "test.example:baz": {
                         "locked": "1.0.0",
@@ -545,8 +535,7 @@ class GenerateLockTaskSpec extends ProjectSpec {
                         ]
                     },
                     "test.example:foobaz": {
-                        "locked": "1.0.0",
-                        "requested": "1.+"
+                        "locked": "1.0.0"
                     }
                 }
             }'''.stripIndent()
@@ -599,8 +588,7 @@ class GenerateLockTaskSpec extends ProjectSpec {
                         ]
                     },
                     "test.example:transitive": {
-                        "locked": "1.0.0",
-                        "requested": "1.0.0"
+                        "locked": "1.0.0"
                     }
                 }
             }'''.stripIndent()
@@ -634,8 +622,7 @@ class GenerateLockTaskSpec extends ProjectSpec {
             {
                 "testRuntimeClasspath": {
                     "test.example:foo": {
-                        "locked": "2.0.1",
-                        "requested": "2.+"
+                        "locked": "2.0.1"
                     }
                 }
             }'''.stripIndent()

--- a/src/test/groovy/nebula/plugin/dependencylock/tasks/MigrateToCoreLocksTaskSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/tasks/MigrateToCoreLocksTaskSpec.groovy
@@ -28,12 +28,10 @@ class MigrateToCoreLocksTaskSpec extends AbstractDependencyLockPluginSpec {
         legacyLockFile.text = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 },
                 "test.nebula:b": {
-                    "locked": "1.1.0",
-                    "requested": "1.+"
+                    "locked": "1.1.0"
                 }'''.stripIndent())
 
         when:
@@ -127,6 +125,52 @@ class MigrateToCoreLocksTaskSpec extends AbstractDependencyLockPluginSpec {
         def expectedNebulaLockText = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
+                    "locked": "1.0.0"
+                },
+                "test.nebula:b": {
+                    "locked": "1.1.0"
+                },
+                "test.nebula:c": {
+                    "locked": "1.0.0"
+                },
+                "test.nebula:d": {
+                    "locked": "1.0.0",
+                    "transitive": [
+                        "test.nebula:c"
+                    ]
+                }'''.stripIndent())
+        legacyLockFile.text = expectedNebulaLockText
+
+        when:
+        def result = runTasks('migrateToCoreLocks')
+
+        then:
+        result.output.contains('coreLockingSupport feature enabled')
+        !result.output.contains('not supported')
+        result.output.contains('Migrating legacy locks')
+        def actualLocks = new File(projectDir, '/gradle/dependency-locks/').list().toList()
+
+        actualLocks.containsAll(expectedLocks)
+        def lockFile = new File(projectDir, '/gradle/dependency-locks/compileClasspath.lockfile')
+        lockFile.text.contains('test.nebula:a:1.0.0')
+        lockFile.text.contains('test.nebula:b:1.1.0')
+        lockFile.text.contains('test.nebula:c:1.0.0')
+        lockFile.text.contains('test.nebula:d:1.0.0')
+
+        !legacyLockFile.exists()
+    }
+
+
+    def 'migration with transitives and reqested values'() {
+        given:
+        buildFile << """
+            dependencies {
+                implementation 'test.nebula:c:1.+'
+            }""".stripIndent()
+        def legacyLockFile = new File(projectDir, 'dependencies.lock')
+        def expectedNebulaLockText = LockGenerator.duplicateIntoConfigs(
+                '''\
+                "test.nebula:a": {
                     "locked": "1.0.0",
                     "requested": "1.+"
                 },
@@ -176,20 +220,16 @@ class MigrateToCoreLocksTaskSpec extends AbstractDependencyLockPluginSpec {
         def expectedNebulaLockText = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 },
                 "test.nebula:b": {
-                    "locked": "1.1.0",
-                    "requested": "1.+"
+                    "locked": "1.1.0"
                 },
                 "test.nebula:c": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 },
                 "test.nebula:e": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 }'''.stripIndent())
         legacyLockFile.text = expectedNebulaLockText
 
@@ -256,16 +296,14 @@ class MigrateToCoreLocksTaskSpec extends AbstractDependencyLockPluginSpec {
         sub1LegacyLockFile.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 }'''.stripIndent())
 
         def sub2LegacyLockFile = new File(projectDir, 'sub2/dependencies.lock')
         sub2LegacyLockFile.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:c": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 },
                 "test.nebula:d": {
                     "locked": "1.0.0",
@@ -334,8 +372,7 @@ class MigrateToCoreLocksTaskSpec extends AbstractDependencyLockPluginSpec {
         sub1LegacyLockFile.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 }'''.stripIndent())
 
         def sub2LegacyLockFile = new File(projectDir, 'sub2/dependencies.lock')
@@ -351,8 +388,7 @@ class MigrateToCoreLocksTaskSpec extends AbstractDependencyLockPluginSpec {
                     ]
                 },
                 "test.nebula:c": {
-                    "locked": "1.0.0",
-                    "requested": "1.0.0"
+                    "locked": "1.0.0"
                 },
                 "test.nebula:d": {
                     "locked": "1.0.0",
@@ -424,8 +460,7 @@ class MigrateToCoreLocksTaskSpec extends AbstractDependencyLockPluginSpec {
         sub1LegacyLockFile.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 }'''.stripIndent())
 
         def sub2LegacyLockFile = new File(projectDir, 'sub2/dependencies.lock')
@@ -436,14 +471,12 @@ class MigrateToCoreLocksTaskSpec extends AbstractDependencyLockPluginSpec {
                 },
                 "test.nebula:a": {
                     "locked": "1.0.0",
-                    "requested": "1.0.0",
                     "transitive": [
                         "${projectName}:sub1"
                     ]
                 },
                 "test.nebula:c": {
-                    "locked": "1.0.0",
-                    "requested": "1.0.0"
+                    "locked": "1.0.0"
                 },
                 "test.nebula:d": {
                     "locked": "1.0.0",
@@ -481,8 +514,7 @@ class MigrateToCoreLocksTaskSpec extends AbstractDependencyLockPluginSpec {
         legacyLockFile.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 }'''.stripIndent())
 
         when:
@@ -591,8 +623,7 @@ class MigrateToCoreLocksTaskSpec extends AbstractDependencyLockPluginSpec {
         legacyLockFile.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 }
                 '''.stripIndent())
 
@@ -673,12 +704,10 @@ class MigrateToCoreLocksTaskSpec extends AbstractDependencyLockPluginSpec {
         legacyLockFile.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 },
                 "test.nebula:b": {
-                    "locked": "1.1.0",
-                    "requested": "1.+"
+                    "locked": "1.1.0"
                 }'''.stripIndent())
 
         buildFile.text = """\
@@ -722,12 +751,10 @@ class MigrateToCoreLocksTaskSpec extends AbstractDependencyLockPluginSpec {
         legacyLockFile.text = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.+"
+                    "locked": "1.0.0"
                 },
                 "test.nebula:b": {
-                    "locked": "1.1.0",
-                    "requested": "1.+"
+                    "locked": "1.1.0"
                 }'''.stripIndent())
 
         buildFile.text = """\
@@ -871,14 +898,12 @@ class MigrateToCoreLocksTaskSpec extends AbstractDependencyLockPluginSpec {
         def locks = LockGenerator.duplicateIntoConfigs(
                 '''\
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.0.0"
+                    "locked": "1.0.0"
                 }'''.stripIndent(),
                 compileBasedConfigs,
                 '''\
                 "junit:junit": {
-                    "locked": "4.12",
-                    "requested": "4.12"
+                    "locked": "4.12"
                 },
                 "org.hamcrest:hamcrest-core": {
                     "locked": "1.3",
@@ -887,8 +912,7 @@ class MigrateToCoreLocksTaskSpec extends AbstractDependencyLockPluginSpec {
                     ]
                 },
                 "test.nebula:a": {
-                    "locked": "1.0.0",
-                    "requested": "1.0.0"
+                    "locked": "1.0.0"
                 }'''.stripIndent(),
                 testCompileBaseConfigs)
         return locks

--- a/src/test/groovy/nebula/plugin/dependencylock/tasks/UpdateLockTaskSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/tasks/UpdateLockTaskSpec.groovy
@@ -48,12 +48,10 @@ class UpdateLockTaskSpec extends ProjectSpec {
         def lockText = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly(
                 '''\
                     "test.example:bar": {
-                        "locked": "1.0.0",
-                        "requested": "1.+"
+                        "locked": "1.0.0"
                     },
                     "test.example:qux": {
-                        "locked": "1.0.0",
-                        "requested": "1.0.0"
+                        "locked": "1.0.0"
                     },
                     "test.example:foo": {
                         "locked": "1.0.0",
@@ -71,8 +69,7 @@ class UpdateLockTaskSpec extends ProjectSpec {
         def updatedLock = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly(
                 '''\
                     "test.example:bar": {
-                        "locked": "1.1.0",
-                        "requested": "1.+"
+                        "locked": "1.1.0"
                     },
                     "test.example:foo": {
                         "locked": "1.0.1",
@@ -82,8 +79,7 @@ class UpdateLockTaskSpec extends ProjectSpec {
                         ]
                     },
                     "test.example:qux": {
-                        "locked": "1.0.0",
-                        "requested": "1.0.0"
+                        "locked": "1.0.0"
                     }'''.stripIndent()
         )
 


### PR DESCRIPTION
Also keep the previous behavior to drop locks for versions without requested versions during a selective dependency update, but this is now done without using the "requested" field in the lock file. (This improves interaction with resolution strategies that affect first order dependencies without versions, like those provided by dependency recommender and Spring dependency management.)