### PR TITLE
Verify resolved dependencies use locked version

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
@@ -19,5 +19,6 @@ class DependencyResolutionVerifierExtension {
     boolean shouldFailTheBuild = true
     Set<String> configurationsToExclude = [] as Set
     String missingVersionsMessageAddition = ''
+    String resolvedVersionDoesNotEqualLockedVersionMessageAddition = ''
     Set<String> tasksToExclude = [] as Set
 }

--- a/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyResolutionVerifier.kt
+++ b/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyResolutionVerifier.kt
@@ -230,7 +230,7 @@ class DependencyResolutionVerifier {
                 else -> ""
             }
 
-            if (expectedVersion != dep.version) {
+            if (expectedVersion.isNotEmpty() && expectedVersion != dep.version) {
                 val depAsString = "${dep.group}:${dep.name}:${dep.version}"
                 val key = "'$depAsString' instead of locked version '$expectedVersion'"
                 if (depsWhereResolvedVersionIsNotTheLockedVersionByConf!!.containsKey(dep.toString())) {

--- a/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
+++ b/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
@@ -788,6 +788,24 @@ class DependencyResolutionVerifierTest extends IntegrationTestKitSpec {
     }
 
     @Unroll
+    def 'resolved versions are not equal to locked versions - handles unlocked transitives - core alignment #coreAlignment - core locking #coreLocking'() {
+        given:
+        setupSingleProjectWithLockedVersionsThatAreNotAligned()
+
+        when:
+        def flags = ["-Dnebula.features.coreAlignmentSupport=${coreAlignment}", "-Dnebula.features.coreLockingSupport=${coreLocking}"]
+        runTasks('generateLock', 'saveLock', *flags) // without locking transitives
+        def results = runTasks('dependencies', '--configuration', 'compileClasspath', *flags)
+
+        then:
+        results.output.contains('SUCCESS')
+
+        where:
+        coreAlignment | coreLocking
+        true          | false
+    }
+
+    @Unroll
     def 'resolved versions are not equal to locked versions with override file - core alignment #coreAlignment - core locking #coreLocking'() {
         given:
         setupSingleProjectWithLockedVersionsThatAreNotAligned()


### PR DESCRIPTION
We can use the `DependencyResolutionVerifier` to enforce that resolved versions are the same as locked versions, as using `useVersion`/`useTarget` does not ensure this for aligned dependencies when the project uses core alignment, and using the dependencySubstitution DSL can cause more failures due to “multiple forces for an aligned platform” since an actual substitution rule and a locked version can get into conflict.

As a recap, we switched from `useTarget/useVersion` to the substitution DSL because we saw when migrating from Nebula alignment to core alignment while using Nebula locks, that aligned dependencies have more weight than values found in the lockfile (since `useTarget/useVersion` are not applied to aligned groups). We chose to honor locked versions and fail early for multiple version conflicts rather than use versions that are different from those in the lockfiles.

However, this caused an issue: when a substitution rule is in effect and the locked version uses the substitution DSL, we can enter a state where there are failures due to multiple forces, when this should be a valid chain of events.

The times that this verification should show an error are when:
- the locked dependencies are not aligned and the locked resolution rules version thinks they should be aligned
- the locked dependencies are not aligned and someone has added a custom rules file/ is using an unlocked resolution rules file (very rare case; this is used for tests more than in projects)
- migrating from Nebula alignment to core Gradle alignment _and_ when the chosen aligned versions are actually different

The error message will look like: 
```
Task failed with an exception.
> Dependency lock state is out of date:
  1. Resolved 'test.nebula:a:1.2.0' instead of locked version '1.1.0' for project 'sub1'
  2. Resolved 'test.nebula:c:1.2.0' instead of locked version '1.1.0' for project 'sub1'
  3. Resolved 'test.nebula:d:1.2.0' instead of locked version '1.1.0' for project 'sub1'
Please update your dependency locks or your build file constraints.
```

and this runs on commands that are a kind of `DependencyReportTask`, `DependencyInsightReportTask`, or `AbstractCompile`