### PR TITLE
Use Kotlin 1.4.10 and add explicit Java 1.8 configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ import org.gradle.util.GradleVersion
 plugins {
     id 'nebula.plugin-plugin' version '14.5.0'
     id 'nebula.optional-base' version '3.1.0'
-    id 'nebula.kotlin' version '1.3.61'
+    id "org.jetbrains.kotlin.jvm" version "1.4.10"
     id 'java-gradle-plugin'
 }
 
@@ -123,5 +123,23 @@ tasks.withType(Test) {
                 println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
             }
         }
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+idea {
+    project {
+        jdkName = '1.8'
+        languageLevel = '1.8'
+    }
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
+    kotlinOptions {
+        jvmTarget = '1.8'
     }
 }

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,4 +1,9 @@
 {
+    "apiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.10"
+        }
+    },
     "compileClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.9.9.20190807",
@@ -21,7 +26,7 @@
             "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
-            "locked": "1.9.2",
+            "locked": "1.11.0",
             "requested": "1.+"
         },
         "joda-time:joda-time": {
@@ -29,8 +34,8 @@
             "requested": "2.10"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.3.61",
-            "requested": "1.3.61"
+            "locked": "1.4.10",
+            "requested": "1.4.10"
         }
     },
     "implementationDependenciesMetadata": {
@@ -55,7 +60,7 @@
             "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
-            "locked": "1.9.2",
+            "locked": "1.11.0",
             "requested": "1.+"
         },
         "joda-time:joda-time": {
@@ -63,8 +68,13 @@
             "requested": "2.10"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.3.61",
-            "requested": "1.3.61"
+            "locked": "1.4.10",
+            "requested": "1.4.10"
+        }
+    },
+    "integTestApiDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.10"
         }
     },
     "integTestCompileClasspath": {
@@ -101,11 +111,11 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.8.6",
+            "locked": "7.9.4",
             "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
-            "locked": "1.9.2",
+            "locked": "1.11.0",
             "requested": "1.+"
         },
         "joda-time:joda-time": {
@@ -117,8 +127,14 @@
             "requested": "3.0.0-beta.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.3.61",
-            "requested": "1.3.61"
+            "locked": "1.4.10",
+            "requested": "1.4.10"
+        }
+    },
+    "integTestImplementationDependenciesMetadata": {
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
+            "locked": "1.4.10",
+            "requested": "1.4.10"
         }
     },
     "integTestRuntimeClasspath": {
@@ -155,11 +171,11 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.8.6",
+            "locked": "7.9.4",
             "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
-            "locked": "1.9.2",
+            "locked": "1.11.0",
             "requested": "1.+"
         },
         "joda-time:joda-time": {
@@ -171,8 +187,8 @@
             "requested": "3.0.0-beta.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.3.61",
-            "requested": "1.3.61"
+            "locked": "1.4.10",
+            "requested": "1.4.10"
         }
     },
     "jacocoAgent": {
@@ -187,13 +203,18 @@
     },
     "kotlinCompilerClasspath": {
         "org.jetbrains.kotlin:kotlin-compiler-embeddable": {
-            "locked": "1.3.61"
+            "locked": "1.4.10"
         }
     },
     "kotlinCompilerPluginClasspath": {
         "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable": {
-            "locked": "1.3.61",
-            "requested": "1.3.61"
+            "locked": "1.4.10",
+            "requested": "1.4.10"
+        }
+    },
+    "kotlinKlibCommonizerClasspath": {
+        "org.jetbrains.kotlin:kotlin-klib-commonizer-embeddable": {
+            "locked": "1.4.10"
         }
     },
     "runtimeClasspath": {
@@ -218,7 +239,7 @@
             "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
-            "locked": "1.9.2",
+            "locked": "1.11.0",
             "requested": "1.+"
         },
         "joda-time:joda-time": {
@@ -226,8 +247,8 @@
             "requested": "2.10"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.3.61",
-            "requested": "1.3.61"
+            "locked": "1.4.10",
+            "requested": "1.4.10"
         }
     },
     "testCompileClasspath": {
@@ -264,11 +285,11 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.8.6",
+            "locked": "7.9.4",
             "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
-            "locked": "1.9.2",
+            "locked": "1.11.0",
             "requested": "1.+"
         },
         "joda-time:joda-time": {
@@ -280,8 +301,8 @@
             "requested": "3.0.0-beta.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.3.61",
-            "requested": "1.3.61"
+            "locked": "1.4.10",
+            "requested": "1.4.10"
         }
     },
     "testImplementationDependenciesMetadata": {
@@ -318,11 +339,11 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.8.6",
+            "locked": "7.9.4",
             "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
-            "locked": "1.9.2",
+            "locked": "1.11.0",
             "requested": "1.+"
         },
         "joda-time:joda-time": {
@@ -334,8 +355,8 @@
             "requested": "3.0.0-beta.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.3.61",
-            "requested": "1.3.61"
+            "locked": "1.4.10",
+            "requested": "1.4.10"
         }
     },
     "testRuntimeClasspath": {
@@ -372,11 +393,11 @@
             "requested": "latest.release"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "7.8.6",
+            "locked": "7.9.4",
             "requested": "latest.release"
         },
         "com.squareup.moshi:moshi": {
-            "locked": "1.9.2",
+            "locked": "1.11.0",
             "requested": "1.+"
         },
         "joda-time:joda-time": {
@@ -388,8 +409,8 @@
             "requested": "3.0.0-beta.1"
         },
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8": {
-            "locked": "1.3.61",
-            "requested": "1.3.61"
+            "locked": "1.4.10",
+            "requested": "1.4.10"
         }
     }
 }


### PR DESCRIPTION
Gradle 6.7.1 is tested through Kotlin 1.4.0 (https://docs.gradle.org/6.7.1/userguide/compatibility.html)

Adding in the kotlinOptions to address the following error:

```
Cannot inline bytecode built with JVM target 1.8 into bytecode that is being built with JVM target 1.6. Please specify proper '-jvm-target' option
```

And adding in related JVM configuration for consistency