### PR TITLE
Use `size` accessor

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/utils/ConfigurationFilters.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/utils/ConfigurationFilters.groovy
@@ -57,7 +57,7 @@ class ConfigurationFilters {
         def method = configuration.metaClass.getMetaMethod('getResolutionAlternatives')
         if (method != null) {
             def alternatives = configuration.getResolutionAlternatives()
-            if (alternatives != null && alternatives.size > 0) {
+            if (alternatives != null && alternatives.size() > 0) {
                 return true
             }
         }


### PR DESCRIPTION
The resolution alternatives are checked using the private `size` field which may not exist for all potential `List` implementations.