### PR TITLE
Verifier and selective dependency updates

### DIFF
--- a/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
+++ b/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
@@ -412,16 +412,10 @@ class DependencyResolutionVerifierTest extends IntegrationTestKitSpec {
 
         where:
         gradleVersionToTest | expecting
+        '6.9'               | 'error'
+        '6.9'               | 'no error'
         '6.0.1'             | 'error'
         '6.0.1'             | 'no error'
-        '5.6.4'             | 'error'
-        '5.6.4'             | 'no error'
-        '5.1'               | 'error'
-        '5.1'               | 'no error'
-        '4.10.3'            | 'error'
-        '4.10.3'            | 'no error'
-        '4.9'               | 'error'
-        '4.9'               | 'no error'
     }
 
     @Unroll


### PR DESCRIPTION
DependencyResolutionVerifier does not verify that the resolved version is the locked version when there has been a selective dependency update in the same command (this is currently only run with using core Gradle alignment and Nebula locking).

The information about which locks should be considered for this validation can show a false-positive, such as when `dependencyReport` is run in the same task invocation as `updateDependency`. This is likely related to dependencies from a recommendation BOM or from aligned dependencies. We can disable this additional validation when running selective dependency lock updates to avoid seeing a false positive error.