### PR TITLE
Remove and flag features incompatible for configuration caching

### DIFF
--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
@@ -1607,7 +1607,7 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
         plugin << ['id \'checkstyle\'', 'id \'jacoco\''] // removed 'id \'net.saliman.cobertura\' version \'2.5.0\'', because it isn't gradle 5.1 compatible yet
     }
 
-    @IgnoreIf({ jvm.isJava17Compatible() }) // Because we use old version of Gradle and koltin
+    @IgnoreIf({ jvm.isJava17Compatible() }) // Because we use old version of Gradle and Kotlin
     @Issue("https://youtrack.jetbrains.com/issue/KT-48245")
     def 'compileOnly configuration is not resolvable for locking'() {
         // the kotlin plugin make this resolvable in Gradle 7
@@ -2037,5 +2037,13 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
 
         then:
         result.standardOutput.contains 'test.example:foo:1.0.1 -> 1.0.0'
+    }
+
+    def 'does not fail with configuration caching enabled'() {
+        when:
+        runTasksSuccessfully('help', '--configuration-cache')
+
+        then:
+        noExceptionThrown()
     }
 }


### PR DESCRIPTION
This appears to be the only place we're obviously incompatible with configuration caching (`Gradle.buildFinished` and `TaskExecutionGraph.addTaskExecutionListener`).

For the latter, the default since Gradle 7 has been a single lock file per-project, so dangling lock files are no longer a concern. Have I followed that logic correctly?

I'm also out of date on the dependency verifier, so I'll need some background on the problem it solves, but for now I'll just turn it off when configuration caching is enabled so I can get this working for Nebula internally.