### PR TITLE
Update dependencies validations

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
@@ -26,5 +26,7 @@ class DependencyLockExtension {
     boolean includeTransitives = false
     boolean lockAfterEvaluating = true
     boolean updateDependenciesFailOnInvalidCoordinates = true
+    boolean updateDependenciesFailOnSimultaneousTaskUsage = true
+    boolean updateDependenciesFailOnNonSpecifiedDependenciesToUpdate = true
     Set<String> additionalConfigurationsToLock = [] as Set
 }

--- a/src/main/kotlin/nebula/plugin/dependencylock/validation/UpdateDependenciesValidator.kt
+++ b/src/main/kotlin/nebula/plugin/dependencylock/validation/UpdateDependenciesValidator.kt
@@ -1,6 +1,12 @@
 package nebula.plugin.dependencylock.validation
 
+import nebula.plugin.dependencylock.DependencyLockExtension
+import nebula.plugin.dependencylock.DependencyLockPlugin.Companion.UPDATE_DEPENDENCIES
+import nebula.plugin.dependencylock.DependencyLockPlugin.Companion.VALIDATE_DEPENDENCY_COORDINATES
+import nebula.plugin.dependencylock.DependencyLockPlugin.Companion.VALIDATE_SIMULTANEOUS_TASKS
+import nebula.plugin.dependencylock.DependencyLockPlugin.Companion.VALIDATE_SPECIFIED_DEPENDENCIES_TO_UPDATE
 import nebula.plugin.dependencylock.exceptions.DependencyLockException
+import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 
@@ -9,29 +15,85 @@ class UpdateDependenciesValidator {
         private val LOGGER: Logger = Logging.getLogger(UpdateDependenciesValidator::class.java)
 
         @JvmStatic
-        fun validate(updateDependencies: Set<String>, failOnError: Boolean) {
+        fun validate(
+            updateDependencies: Set<String>, overrides: Map<*, *>,
+            hasUpdateTask: Boolean, hasGenerateTask: Boolean,
+            project: Project,
+            extension: DependencyLockExtension
+        ) {
+            val validateCoordinates =
+                if (project.hasProperty(VALIDATE_DEPENDENCY_COORDINATES)) project.property(
+                    VALIDATE_DEPENDENCY_COORDINATES
+                ).toString().toBoolean() else extension.updateDependenciesFailOnInvalidCoordinates
+            val validateSimultaneousTasks =
+                if (project.hasProperty(VALIDATE_SIMULTANEOUS_TASKS)) project.property(
+                    VALIDATE_SIMULTANEOUS_TASKS
+                ).toString().toBoolean() else extension.updateDependenciesFailOnSimultaneousTaskUsage
+            val validateSpecifiedDependenciesToUpdate =
+                if (project.hasProperty(VALIDATE_SPECIFIED_DEPENDENCIES_TO_UPDATE)) project.property(
+                    VALIDATE_SPECIFIED_DEPENDENCIES_TO_UPDATE
+                ).toString().toBoolean() else extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate
+
+            validateCoordinates(updateDependencies, validateCoordinates)
+            validateSimultaneousTasks(hasUpdateTask, hasGenerateTask, validateSimultaneousTasks)
+            validateSpecifiedDependenciesToUpdate(
+                hasUpdateTask,
+                updateDependencies,
+                overrides,
+                validateSpecifiedDependenciesToUpdate
+            )
+        }
+
+        private fun validateCoordinates(updateDependencies: Set<String>, failOnError: Boolean) {
             val errors = mutableListOf<String>()
             updateDependencies.forEach { coordinate ->
-                if(coordinate.isEmpty()) {
+                if (coordinate.isEmpty()) {
                     errors.add("An empty element exists in the list")
-                }
-                else if(coordinate.split(":").size == 1) {
+                } else if (coordinate.split(":").size == 1) {
                     errors.add("$coordinate does not contain groupId:module. Only has one element")
-                }
-                else if(coordinate.split(":").size > 2) {
+                } else if (coordinate.split(":").size > 2) {
                     errors.add("$coordinate contains more elements than groupId:module. Version and classifiers are not supported")
                 }
-                if(coordinate.contains(";")) {
+                if (coordinate.contains(";")) {
                     errors.add("$coordinate contains ; which is invalid")
                 }
             }
-            if(errors.isEmpty()) {
+            if (errors.isEmpty()) {
                 return
             }
-            if(failOnError) {
+            if (failOnError) {
                 throw DependencyLockException("updateDependencies list is invalid | Errors: ${errors.joinToString("\n")}")
             } else {
                 LOGGER.error("updateDependencies list is invalid | Errors: ${errors.joinToString("\n")}")
+            }
+        }
+
+        @JvmStatic
+        private fun validateSimultaneousTasks(hasUpdateTask: Boolean, hasGenerateTask: Boolean, failOnError: Boolean) {
+            if (hasUpdateTask && hasGenerateTask) {
+                val error =
+                    "Using `generateLock` and `updateLock` in the same build will result in re-resolving all locked dependencies. " +
+                            "Please invoke only one of these tasks at a time."
+                if (failOnError) {
+                    throw DependencyLockException(error)
+                } else {
+                    LOGGER.error(error)
+                }
+            }
+        }
+
+        private fun validateSpecifiedDependenciesToUpdate(
+            hasUpdateTask: Boolean, updates: Set<String>, overrides: Map<*, *>, failOnError: Boolean
+        ) {
+            if (hasUpdateTask && updates.isEmpty() && overrides.isEmpty()) {
+                val error =
+                    "Please specify dependencies to update, such as with `-P${UPDATE_DEPENDENCIES}=com.example:foo,com.example:bar`. " +
+                            "You can bypass this fail-fast validation with `-P${VALIDATE_SPECIFIED_DEPENDENCIES_TO_UPDATE}=false`"
+                if (failOnError) {
+                    throw DependencyLockException(error)
+                } else {
+                    LOGGER.error(error)
+                }
             }
         }
     }

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
@@ -521,6 +521,29 @@ class DependencyLockLauncherSpec extends IntegrationSpec {
         new File(projectDir, 'dependencies.lock').text == FOO_LOCK
     }
 
+    def 'update lock requires dependencies to update by default'() {
+        def dependenciesLock = new File(projectDir, 'dependencies.lock')
+        dependenciesLock << REMOVE_UPDATE_LOCK
+        buildFile.text = BUILD_GRADLE
+
+        when:
+        def result = runTasksWithFailure('updateLock', 'saveLock')
+
+        then:
+        result.standardError.contains("Please specify dependencies to update")
+    }
+
+    def 'update lock uses property when intending to run with no dependencies to update passed in'() {
+        def dependenciesLock = new File(projectDir, 'dependencies.lock')
+        dependenciesLock << REMOVE_UPDATE_LOCK
+        buildFile.text = BUILD_GRADLE
+        when:
+        runTasksSuccessfully('-PdependencyLock.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate=false', 'updateLock', 'saveLock')
+
+        then:
+        new File(projectDir, 'dependencies.lock').text == FOO_LOCK
+    }
+
     def 'command line override file respected while generating lock'() {
         def testLock = new File(projectDir, 'test.lock')
         testLock << FOO_LOCK_OVERRIDE

--- a/src/test/groovy/nebula/plugin/dependencylock/validation/UpdateDependenciesValidatorSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/validation/UpdateDependenciesValidatorSpec.groovy
@@ -1,14 +1,22 @@
 package nebula.plugin.dependencylock.validation
 
+import nebula.plugin.dependencylock.DependencyLockExtension
 import nebula.plugin.dependencylock.exceptions.DependencyLockException
-import spock.lang.Specification
+import nebula.test.ProjectSpec
 
-class UpdateDependenciesValidatorSpec extends Specification {
+class UpdateDependenciesValidatorSpec extends ProjectSpec {
+    private static final HashMap<Object, Object> emptyMap = new HashMap<Object, Object>()
+    private static final DependencyLockExtension extension = DependencyLockExtension.newInstance()
+    private static final String pluginName = 'nebula.dependency-lock'
+
+    def setup() {
+        project.apply plugin: pluginName
+    }
 
     def 'should not fail if valid coordinates'() {
         when:
         Set<String> modules = ["netflix:my-module", "netflix:my-module-2"]
-        UpdateDependenciesValidator.validate(modules,true)
+        UpdateDependenciesValidator.validate(modules, emptyMap, true, false, project, extension)
 
         then:
         notThrown(DependencyLockException)
@@ -17,7 +25,7 @@ class UpdateDependenciesValidatorSpec extends Specification {
     def 'should fail if invalid coordinates'() {
         when:
         Set<String> modules = ["netflix", "netflix:my-module:1.+", "netflix:my-module-2:latest.release", "netflix:my-module;2:latest.release"]
-        UpdateDependenciesValidator.validate(modules,true)
+        UpdateDependenciesValidator.validate(modules, emptyMap, true, false, project, extension)
 
         then:
         def exception = thrown(DependencyLockException)
@@ -30,8 +38,80 @@ class UpdateDependenciesValidatorSpec extends Specification {
 
     def 'should not fail if invalid coordinates but disabled validation'() {
         when:
+        project.ext.set('dependencyLock.updateDependenciesFailOnInvalidCoordinates', false)
         Set<String> modules = ["netflix", "netflix:my-module:1.+", "netflix:my-module-2:latest.release", "netflix:my-module;2:latest.release"]
-        UpdateDependenciesValidator.validate(modules,false)
+        UpdateDependenciesValidator.validate(modules, emptyMap, true, false, project, extension)
+
+        then:
+        notThrown(DependencyLockException)
+    }
+
+    def 'should not fail when calling one locking generation command - generateLock'() {
+        when:
+        Set<String> modules = []
+        UpdateDependenciesValidator.validate(modules, emptyMap, false, true, project, extension)
+
+        then:
+        notThrown(DependencyLockException)
+    }
+
+    def 'should not fail when calling one locking generation command - updateLock'() {
+        when:
+        Set<String> modules = ["netflix:my-module", "netflix:my-module-2"]
+        UpdateDependenciesValidator.validate(modules, emptyMap, true, false, project, extension)
+
+        then:
+        notThrown(DependencyLockException)
+    }
+
+    def 'should fail when calling generateLock and updateLock together'() {
+        when:
+        Set<String> modules = ["netflix:my-module", "netflix:my-module-2"]
+        UpdateDependenciesValidator.validate(modules, emptyMap, true, true, project, extension)
+
+        then:
+        def exception = thrown(DependencyLockException)
+        exception.message.contains("Using `generateLock` and `updateLock` in the same build will result in re-resolving all locked dependencies.")
+        exception.message.contains("Please invoke only one of these tasks at a time.")
+    }
+
+    def 'should not fail when calling generateLock and updateLock together but disabled validation'() {
+        when:
+        project.ext.set('dependencyLock.updateDependenciesFailOnSimultaneousTaskUsage', false)
+        Set<String> modules = ["netflix:my-module", "netflix:my-module-2"]
+        UpdateDependenciesValidator.validate(modules, emptyMap, true, true, project, extension)
+
+        then:
+        notThrown(DependencyLockException)
+    }
+
+    def 'should not fail when only overrides are requested'() {
+        when:
+        Set<String> modules = []
+        Map<String, String> overrides = new HashMap<>()
+        overrides.put("netflix:my-module", "1.0.0")
+        overrides.put("netflix:my-module-2", "1.0.0")
+        UpdateDependenciesValidator.validate(modules, overrides, true, false, project, extension)
+
+        then:
+        notThrown(DependencyLockException)
+    }
+
+    def 'should fail when no modules to update and no overrides are passed in'() {
+        when:
+        Set<String> modules = []
+        UpdateDependenciesValidator.validate(modules, emptyMap, true, false, project, extension)
+
+        then:
+        def exception = thrown(DependencyLockException)
+        exception.message.contains("Please specify dependencies to update")
+    }
+
+    def 'should not fail when no modules to update and no overrides are passed in but disabled validation'() {
+        when:
+        project.ext.set('dependencyLock.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate', false)
+        Set<String> modules = []
+        UpdateDependenciesValidator.validate(modules, emptyMap, true, false, project, extension)
 
         then:
         notThrown(DependencyLockException)


### PR DESCRIPTION
Setting usage expectations with validations:

- Validation for simultaneous task usage of `updateLock` & `generateLock` which should not be used together
- Validation for requiring specifying dependencies to update when calling `updateLock`

These are both bypass-able default validations with a property or extension. 