### PR TITLE
GenerateLockTask: use configuration cache compatible APIs

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/model/ConfigurationResolutionData.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/model/ConfigurationResolutionData.groovy
@@ -1,0 +1,13 @@
+package nebula.plugin.dependencylock.model
+
+import groovy.transform.Canonical
+import org.gradle.api.artifacts.result.DependencyResult
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.provider.Provider
+
+@Canonical
+class ConfigurationResolutionData {
+    String configurationName
+    Collection<DependencyResult> allDependencies
+    Provider<ResolvedComponentResult> resolvedComponentResult
+}

--- a/src/test/groovy/nebula/plugin/dependencylock/ResolutionRulesLockabilitySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/ResolutionRulesLockabilitySpec.groovy
@@ -106,22 +106,22 @@ class ResolutionRulesLockabilitySpec extends IntegrationTestKitSpec {
 {
     "_global_": {
         "commons-io:commons-io": {
-            "firstLevelTransitive": [
+            "locked": "2.11.0",
+            "transitive": [
                 "$moduleName:sub2"
-            ],
-            "locked": "2.11.0"
+            ]
         },
         "commons-logging:commons-logging": {
-            "firstLevelTransitive": [
+            "locked": "1.2",
+            "transitive": [
                 "$moduleName:sub3"
-            ],
-            "locked": "1.2"
+            ]
         },
         "$moduleName:sub1": {
-            "firstLevelTransitive": [
+            "project": true,
+            "transitive": [
                 "$moduleName:sub2"
-            ],
-            "project": true
+            ]
         },
         "$moduleName:sub2": {
             "project": true
@@ -130,11 +130,10 @@ class ResolutionRulesLockabilitySpec extends IntegrationTestKitSpec {
             "project": true
         },
         "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
-                "$moduleName:sub1",
+            "locked": "3.12.0",
+            "transitive": [
                 "$moduleName:sub1"
-            ],
-            "locked": "3.12.0"
+            ]
         }
     },
     "resolutionRules": {
@@ -178,10 +177,10 @@ class ResolutionRulesLockabilitySpec extends IntegrationTestKitSpec {
                 "project": true
             },
             "test.rules:resolution-rules": {
-                "firstLevelTransitive": [
+                "locked": "1.0.0",
+                "transitive": [
                     ":$moduleName"
-                ],
-                "locked": "1.0.0"
+                ]
             }""".stripIndent(), ['resolutionRules'])
 
         def sub2LockText = LockGenerator.duplicateIntoConfigs("""\
@@ -189,10 +188,10 @@ class ResolutionRulesLockabilitySpec extends IntegrationTestKitSpec {
             "locked": "2.11.0"
         },
         "org.apache.commons:commons-lang3": {
-            "firstLevelTransitive": [
+            "locked": "3.12.0",
+            "transitive": [
                 "$moduleName:sub1"
-            ],
-            "locked": "3.12.0"
+            ]
         },
         "$moduleName:sub1": {
             "project": true
@@ -209,10 +208,10 @@ class ResolutionRulesLockabilitySpec extends IntegrationTestKitSpec {
             "project": true
         },
         "test.rules:resolution-rules": {
-            "firstLevelTransitive": [
+            "locked": "1.0.0",
+            "transitive": [
                 ":$moduleName"
-            ],
-            "locked": "1.0.0"
+            ]
         }""".stripIndent(), ['resolutionRules'])
 
         def sub3LockText = LockGenerator.duplicateIntoConfigs('''\
@@ -224,10 +223,10 @@ class ResolutionRulesLockabilitySpec extends IntegrationTestKitSpec {
                 "project": true
             },
             "test.rules:resolution-rules": {
-                "firstLevelTransitive": [
+                "locked": "1.0.0",
+                "transitive": [
                     ":$moduleName"
-                ],
-                "locked": "1.0.0"
+                ]
             }""".stripIndent(), ['resolutionRules'])
 
         rootLockFile.text == rootLockText

--- a/src/test/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTaskSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTaskSpec.groovy
@@ -16,6 +16,7 @@
 package nebula.plugin.dependencylock.tasks
 
 import nebula.plugin.dependencylock.dependencyfixture.Fixture
+import nebula.plugin.dependencylock.model.ConfigurationResolutionData
 import nebula.plugin.dependencylock.model.LockKey
 import nebula.plugin.dependencylock.util.LockGenerator
 import nebula.test.ProjectSpec
@@ -45,7 +46,13 @@ class GenerateLockTaskSpec extends ProjectSpec {
         task.configurationNames.set(['testRuntimeClasspath'])
         task.configure { generateLockTask ->
             generateLockTask.conventionMapping.with {
-                configurations = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>)
+                configurationResolutionData = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>).findAll { it.isCanBeResolved() }.collect {
+                    new ConfigurationResolutionData(
+                            it.name,
+                            it.incoming.resolutionResult.getAllDependencies(),
+                            it.incoming.resolutionResult.rootComponent
+                    )
+                }
             }
         }
 
@@ -86,7 +93,13 @@ class GenerateLockTaskSpec extends ProjectSpec {
 
         task.configure { generateLockTask ->
             generateLockTask.conventionMapping.with {
-                configurations = lockableConfigurations(project, configurationNames)
+                configurationResolutionData = lockableConfigurations(project, configurationNames).findAll { it.isCanBeResolved() }.collect {
+                    new ConfigurationResolutionData(
+                            it.name,
+                            it.incoming.resolutionResult.getAllDependencies(),
+                            it.incoming.resolutionResult.rootComponent
+                    )
+                }
             }
         }
 
@@ -128,7 +141,13 @@ class GenerateLockTaskSpec extends ProjectSpec {
         task.skippedConfigurationNames.set(skippedConfigurationNames)
         task.configure { generateLockTask ->
             generateLockTask.conventionMapping.with {
-                configurations = lockableConfigurations(project, configurationNames, skippedConfigurationNames)
+                configurationResolutionData = lockableConfigurations(project, configurationNames, skippedConfigurationNames).findAll { it.isCanBeResolved() }.collect {
+                    new ConfigurationResolutionData(
+                            it.name,
+                            it.incoming.resolutionResult.getAllDependencies(),
+                            it.incoming.resolutionResult.rootComponent
+                    )
+                }
             }
         }
 
@@ -160,7 +179,13 @@ class GenerateLockTaskSpec extends ProjectSpec {
         task.includeTransitives.set(true)
         task.configure { generateLockTask ->
             generateLockTask.conventionMapping.with {
-                configurations = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>)
+                configurationResolutionData = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>).findAll { it.isCanBeResolved() }.collect {
+                    new ConfigurationResolutionData(
+                            it.name,
+                            it.incoming.resolutionResult.getAllDependencies(),
+                            it.incoming.resolutionResult.rootComponent
+                    )
+                }
             }
         }
 
@@ -208,7 +233,13 @@ class GenerateLockTaskSpec extends ProjectSpec {
         task.configurationNames.set( ['testRuntimeClasspath'])
         task.configure { generateLockTask ->
             generateLockTask.conventionMapping.with {
-                configurations = lockableConfigurations(app, ['testRuntimeClasspath'] as Set<String>)
+                configurationResolutionData = lockableConfigurations(app, ['testRuntimeClasspath'] as Set<String>).findAll { it.isCanBeResolved() }.collect {
+                    new ConfigurationResolutionData(
+                            it.name,
+                            it.incoming.resolutionResult.getAllDependencies(),
+                            it.incoming.resolutionResult.rootComponent
+                    )
+                }
             }
         }
         task.peers.set(app.rootProject.allprojects.collect { new LockKey(group: it.group, artifact: it.name) })
@@ -259,7 +290,13 @@ class GenerateLockTaskSpec extends ProjectSpec {
         task.includeTransitives.set(true)
         task.configure { generateLockTask ->
             generateLockTask.conventionMapping.with {
-                configurations = lockableConfigurations(app, ['testRuntimeClasspath'] as Set<String>)
+                configurationResolutionData = lockableConfigurations(app, ['testRuntimeClasspath'] as Set<String>).findAll { it.isCanBeResolved() }.collect {
+                    new ConfigurationResolutionData(
+                            it.name,
+                            it.incoming.resolutionResult.getAllDependencies(),
+                            it.incoming.resolutionResult.rootComponent
+                    )
+                }
             }
         }
         task.peers.set(app.rootProject.allprojects.collect { new LockKey(group: it.group, artifact: it.name) })
@@ -318,7 +355,13 @@ class GenerateLockTaskSpec extends ProjectSpec {
         task.configurationNames.set(['testRuntimeClasspath'])
         task.configure { generateLockTask ->
             generateLockTask.conventionMapping.with {
-                configurations = lockableConfigurations(app, ['testRuntimeClasspath'] as Set<String>)
+                configurationResolutionData = lockableConfigurations(app, ['testRuntimeClasspath'] as Set<String>).findAll { it.isCanBeResolved() }.collect {
+                    new ConfigurationResolutionData(
+                            it.name,
+                            it.incoming.resolutionResult.getAllDependencies(),
+                            it.incoming.resolutionResult.rootComponent
+                    )
+                }
             }
         }
         task.peers.set(app.rootProject.allprojects.collect { new LockKey(group: it.group, artifact: it.name) })
@@ -331,23 +374,23 @@ class GenerateLockTaskSpec extends ProjectSpec {
             {
                 "testRuntimeClasspath": {
                     "test.example:baz": {
-                        "firstLevelTransitive": [
+                        "locked": "2.0.0",
+                        "transitive": [
                             "test.nebula:common",
                             "test.nebula:lib"
-                        ],
-                        "locked": "2.0.0"
+                        ]
                     },
                     "test.example:foo": {
-                        "firstLevelTransitive": [
+                        "locked": "2.0.1",
+                        "transitive": [
                             "test.nebula:common"
-                        ],
-                        "locked": "2.0.1"
+                        ]
                     },
                     "test.nebula:common": {
-                        "firstLevelTransitive": [
+                        "project": true,
+                        "transitive": [
                             "test.nebula:lib"
-                        ],
-                        "project": true
+                        ]
                     },
                     "test.nebula:lib": {
                         "project": true
@@ -398,7 +441,13 @@ class GenerateLockTaskSpec extends ProjectSpec {
         task.configurationNames.set(['testRuntimeClasspath'])
         task.configure { generateLockTask ->
             generateLockTask.conventionMapping.with {
-                configurations = lockableConfigurations(app, ['testRuntimeClasspath'] as Set<String>)
+                configurationResolutionData = lockableConfigurations(app, ['testRuntimeClasspath'] as Set<String>).findAll { it.isCanBeResolved() }.collect {
+                    new ConfigurationResolutionData(
+                            it.name,
+                            it.incoming.resolutionResult.getAllDependencies(),
+                            it.incoming.resolutionResult.rootComponent
+                    )
+                }
             }
         }
         task.peers.set(app.rootProject.allprojects.collect { new LockKey(group: it.group, artifact: it.name) })
@@ -411,26 +460,26 @@ class GenerateLockTaskSpec extends ProjectSpec {
             {
                 "testRuntimeClasspath": {
                     "test.example:foo": {
-                        "firstLevelTransitive": [
+                        "locked": "2.0.1",
+                        "transitive": [
                             "test.nebula:model"
-                        ],
-                        "locked": "2.0.1"
+                        ]
                     },
                     "test.nebula:common": {
-                        "firstLevelTransitive": [
+                        "project": true,
+                        "transitive": [
                             "test.nebula:lib"
-                        ],
-                        "project": true
+                        ]
                     },
                     "test.nebula:lib": {
                         "project": true
                     },
                     "test.nebula:model": {
-                        "firstLevelTransitive": [
+                        "project": true,
+                        "transitive": [
                             "test.nebula:common",
                             "test.nebula:lib"
-                        ],
-                        "project": true
+                        ]
                     }
                 }
             }'''.stripIndent()
@@ -451,7 +500,13 @@ class GenerateLockTaskSpec extends ProjectSpec {
         task.includeTransitives.set true
         task.configure { generateLockTask ->
             generateLockTask.conventionMapping.with {
-                configurations = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>)
+                configurationResolutionData = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>).findAll { it.isCanBeResolved() }.collect {
+                    new ConfigurationResolutionData(
+                            it.name,
+                            it.incoming.resolutionResult.getAllDependencies(),
+                            it.incoming.resolutionResult.rootComponent
+                    )
+                }
             }
         }
 
@@ -490,7 +545,13 @@ class GenerateLockTaskSpec extends ProjectSpec {
         task.includeTransitives.set true
         task.configure { generateLockTask ->
             generateLockTask.conventionMapping.with {
-                configurations = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>)
+                configurationResolutionData = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>).findAll { it.isCanBeResolved() }.collect {
+                    new ConfigurationResolutionData(
+                            it.name,
+                            it.incoming.resolutionResult.getAllDependencies(),
+                            it.incoming.resolutionResult.rootComponent
+                    )
+                }
             }
         }
 
@@ -532,7 +593,13 @@ class GenerateLockTaskSpec extends ProjectSpec {
         task.includeTransitives.set true
         task.configure { generateLockTask ->
             generateLockTask.conventionMapping.with {
-                configurations = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>)
+                configurationResolutionData = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>).findAll { it.isCanBeResolved() }.collect {
+                    new ConfigurationResolutionData(
+                            it.name,
+                            it.incoming.resolutionResult.getAllDependencies(),
+                            it.incoming.resolutionResult.rootComponent
+                    )
+                }
             }
         }
 
@@ -579,7 +646,13 @@ class GenerateLockTaskSpec extends ProjectSpec {
         task.includeTransitives.set true
         task.configure { generateLockTask ->
             generateLockTask.conventionMapping.with {
-                configurations = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>)
+                configurationResolutionData = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>).findAll { it.isCanBeResolved() }.collect {
+                    new ConfigurationResolutionData(
+                            it.name,
+                            it.incoming.resolutionResult.getAllDependencies(),
+                            it.incoming.resolutionResult.rootComponent
+                    )
+                }
             }
         }
         when:
@@ -627,7 +700,13 @@ class GenerateLockTaskSpec extends ProjectSpec {
         task.includeTransitives.set true
         task.configure { generateLockTask ->
             generateLockTask.conventionMapping.with {
-                configurations = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>)
+                configurationResolutionData = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>).findAll { it.isCanBeResolved() }.collect {
+                    new ConfigurationResolutionData(
+                            it.name,
+                            it.incoming.resolutionResult.getAllDependencies(),
+                            it.incoming.resolutionResult.rootComponent
+                    )
+                }
             }
         }
         when:
@@ -686,7 +765,13 @@ class GenerateLockTaskSpec extends ProjectSpec {
         task.filter.set(filter as Closure)
         task.configure { generateLockTask ->
             generateLockTask.conventionMapping.with {
-                configurations = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>)
+                configurationResolutionData = lockableConfigurations(project, ['testRuntimeClasspath'] as Set<String>).findAll { it.isCanBeResolved() }.collect {
+                    new ConfigurationResolutionData(
+                            it.name,
+                            it.incoming.resolutionResult.getAllDependencies(),
+                            it.incoming.resolutionResult.rootComponent
+                    )
+                }
             }
         }
 

--- a/src/test/groovy/nebula/plugin/dependencylock/tasks/UpdateLockTaskSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/tasks/UpdateLockTaskSpec.groovy
@@ -16,6 +16,7 @@
 package nebula.plugin.dependencylock.tasks
 
 import nebula.plugin.dependencylock.dependencyfixture.Fixture
+import nebula.plugin.dependencylock.model.ConfigurationResolutionData
 import nebula.plugin.dependencylock.util.LockGenerator
 import nebula.test.ProjectSpec
 
@@ -39,7 +40,13 @@ class UpdateLockTaskSpec extends ProjectSpec {
         task.configurationNames = LockGenerator.DEFAULT_CONFIG_NAMES
         task.configure { generateLockTask ->
             generateLockTask.conventionMapping.with {
-                configurations = lockableConfigurations(project, LockGenerator.DEFAULT_CONFIG_NAMES as Set<String>)
+                configurationResolutionData = lockableConfigurations(project, LockGenerator.DEFAULT_CONFIG_NAMES as Set<String>).findAll { it.isCanBeResolved() }.collect {
+                    new ConfigurationResolutionData(
+                            it.name,
+                            it.incoming.resolutionResult.getAllDependencies(),
+                            it.incoming.resolutionResult.rootComponent
+                    )
+                }
             }
         }
         task


### PR DESCRIPTION
This is the next step in our journey to configuration cache

* Replaces usages of `Configuration` at task level since it is not supported in configuration cache. Instead this uses `Provider<ResolvedComponentResult>` as suggested in https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:disallowed_types
* Introduces a few breaking changes:
   * Removes the concept of `includeTransitives` when executing: Because the lazy model is not aware of children and such, it makes more difficult do the sibling navigation. Also, I think this is a decent trade-off: removing complexity in the task and really we want people to always lock all dependencies since locking first level/direct is never enough. 
   * The order on which version and `transitive` field is written change a bit but since there is no JSON schema validation, we are good here

You will notice that there are other parts of this code using Lazy APIs already and that might be a surprise. Indeed, I addressed a lot of this in the following PRs:

* https://github.com/nebula-plugins/gradle-dependency-lock-plugin/pull/250
* https://github.com/nebula-plugins/gradle-dependency-lock-plugin/pull/251
* https://github.com/nebula-plugins/gradle-dependency-lock-plugin/pull/252
* https://github.com/nebula-plugins/gradle-dependency-lock-plugin/pull/253
* https://github.com/nebula-plugins/gradle-dependency-lock-plugin/pull/254
* https://github.com/nebula-plugins/gradle-dependency-lock-plugin/pull/255
* https://github.com/nebula-plugins/gradle-dependency-lock-plugin/pull/256

What's pending/next?

As you can notice, the we still use conventions to configure the configuration information via 

```
generateLockTask.conventionMapping.with {
                configurationResolutionData = lockableConfigurations(project, extension.configurationNames.get(), extension.skippedConfigurationNamesPrefixes.get()).findAll { it.isCanBeResolved() }.collect {
                    new ConfigurationResolutionData(
                            it.name,
                            it.incoming.resolutionResult.getAllDependencies(),
                            it.incoming.resolutionResult.rootComponent
                    )
                }
            }
```

This is also configuration cache incompatible. The next step is to move this into using lazy properties to pass this information. I suspect we need to work a bit on this to avoid eager resolution but we are getting there

Also, I was wondering if it makes sense to even drop the `transitive` nodes from the contract. Since `rootComponent` is lazy and knows all the resolved dependencies, we really shouldn't care if they came directly or transitively anymore (similar to core locks). I acknowledge this will break the contract in the JSON file but I suspect it will make it easier to digest and close to Gradle Core Locking, let's chat about it 