### PR TITLE
Mark tasks as incompatible with config cache

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
@@ -172,6 +172,7 @@ class DependencyLockTaskConfigurer {
     private static void configureCommonSaveTask(TaskProvider<SaveLockTask> saveLockTask, TaskProvider<GenerateLockTask> lockTask,
                                                 TaskProvider<UpdateLockTask> updateTask) {
         saveLockTask.configure { saveTask ->
+            saveTask.notCompatibleWithConfigurationCache("Dependency locking plugin tasks require project access. Please consider using Gradle's dependency locking mechanism")
             saveTask.mustRunAfter lockTask, updateTask
             saveTask.outputs.upToDateWhen {
                 if (saveTask.generatedLock.exists() && saveTask.outputLock.exists()) {
@@ -221,6 +222,7 @@ class DependencyLockTaskConfigurer {
 
     private void setupLockConventionMapping(TaskProvider<GenerateLockTask> task, DependencyLockExtension extension, Map overrideMap) {
         task.configure { generateTask ->
+            generateTask.notCompatibleWithConfigurationCache("Dependency locking plugin tasks require project access. Please consider using Gradle's dependency locking mechanism")
             generateTask.conventionMapping.with {
                 skippedDependencies = { extension.skippedDependencies }
                 includeTransitives = {
@@ -236,6 +238,7 @@ class DependencyLockTaskConfigurer {
                                                                    DependencyLockExtension extension, Map overrides) {
         setupLockConventionMapping(globalLockTask, extension, overrides)
         globalLockTask.configure { globalGenerateTask ->
+            globalGenerateTask.notCompatibleWithConfigurationCache("Dependency locking plugin tasks require project access. Please consider using Gradle's dependency locking mechanism")
             globalGenerateTask.doFirst {
                 project.subprojects.each { sub -> sub.repositories.each { repo -> project.repositories.add(repo) } }
             }
@@ -287,6 +290,8 @@ class DependencyLockTaskConfigurer {
                 inputLockFile = { lockFile }
                 outputLock = { dependencyLock }
             }
+            it.notCompatibleWithConfigurationCache("Dependency locking plugin tasks require project access. Please consider using Gradle's dependency locking mechanism")
+
         }
 
         migrateToCoreLocksTask.configure {
@@ -295,6 +300,7 @@ class DependencyLockTaskConfigurer {
                 outputLock = { dependencyLock }
             }
             it.dependsOn project.tasks.named(MIGRATE_LOCKED_DEPS_TO_CORE_LOCKS_TASK_NAME)
+            it.notCompatibleWithConfigurationCache("Dependency locking plugin tasks require project access. Please consider using Gradle's dependency locking mechanism")
         }
 
         migrateToCoreLocksTask
@@ -304,6 +310,7 @@ class DependencyLockTaskConfigurer {
         TaskProvider<Delete> deleteLockTask = project.tasks.register('deleteLock', Delete)
 
         deleteLockTask.configure { it ->
+            it.notCompatibleWithConfigurationCache("Dependency locking plugin tasks require project access. Please consider using Gradle's dependency locking mechanism")
             it.delete saveLock.map { it.outputLock }
         }
 
@@ -313,6 +320,7 @@ class DependencyLockTaskConfigurer {
         TaskProvider<Delete> deleteGlobalLockTask = project.tasks.register('deleteGlobalLock', Delete)
 
         deleteGlobalLockTask.configure { it ->
+            it.notCompatibleWithConfigurationCache("Dependency locking plugin tasks require project access. Please consider using Gradle's dependency locking mechanism")
             it.delete saveGlobalLock.map { it.outputLock }
         }
     }
@@ -330,6 +338,7 @@ class DependencyLockTaskConfigurer {
         TaskProvider<DiffLockTask> diffLockTask = project.tasks.register(DIFF_LOCK_TASK_NAME, DiffLockTask)
 
         diffLockTask.configure { diffTask ->
+            diffTask.notCompatibleWithConfigurationCache("Dependency locking plugin tasks require project access. Please consider using Gradle's dependency locking mechanism")
             diffTask.mustRunAfter(project.tasks.named(GENERATE_LOCK_TASK_NAME), project.tasks.named(UPDATE_LOCK_TASK_NAME))
             def existing = new File(project.projectDir, lockFileName ?: extension.lockFile)
             if (existing.exists()) {

--- a/src/test/groovy/nebula/plugin/BaseIntegrationTestKitSpec.groovy
+++ b/src/test/groovy/nebula/plugin/BaseIntegrationTestKitSpec.groovy
@@ -1,0 +1,19 @@
+package nebula.plugin
+
+import nebula.test.IntegrationTestKitSpec
+
+abstract class BaseIntegrationTestKitSpec extends IntegrationTestKitSpec {
+    def setup() {
+        // Enable configuration cache to make sure we don't break builds
+        new File(projectDir, 'gradle.properties') << '''org.gradle.configuration-cache=true'''.stripIndent()
+    }
+
+    void disableConfigurationCache() {
+        def propertiesFile = new File(projectDir, 'gradle.properties')
+        if(propertiesFile.exists()) {
+            propertiesFile.delete()
+        }
+        propertiesFile.createNewFile()
+        propertiesFile << '''org.gradle.configuration-cache=false'''.stripIndent()
+    }
+}

--- a/src/test/groovy/nebula/plugin/dependencylock/AbstractDependencyLockPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/AbstractDependencyLockPluginSpec.groovy
@@ -1,15 +1,10 @@
 package nebula.plugin.dependencylock
 
-import nebula.plugin.dependencylock.utils.GradleVersionUtils
-import nebula.test.IntegrationTestKitSpec
+import nebula.plugin.BaseIntegrationTestKitSpec
 import nebula.test.dependencies.DependencyGraphBuilder
 import nebula.test.dependencies.GradleDependencyGenerator
 import nebula.test.dependencies.ModuleBuilder
-import org.gradle.util.GradleVersion
-import org.junit.Rule
-import org.junit.contrib.java.lang.system.ProvideSystemProperty
-
-class AbstractDependencyLockPluginSpec extends IntegrationTestKitSpec {
+class AbstractDependencyLockPluginSpec extends BaseIntegrationTestKitSpec {
     def expectedLocks = [
             'annotationProcessor',
             'compileClasspath',

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockAlignmentLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockAlignmentLauncherSpec.groovy
@@ -13,8 +13,8 @@
  */
 package nebula.plugin.dependencylock
 
+import nebula.plugin.BaseIntegrationTestKitSpec
 import nebula.plugin.dependencyverifier.DependencyResolutionVerifierKt
-import nebula.test.IntegrationTestKitSpec
 import nebula.test.dependencies.DependencyGraphBuilder
 import nebula.test.dependencies.GradleDependencyGenerator
 import spock.lang.Ignore
@@ -27,10 +27,11 @@ import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
 
 @Subject(DependencyResolutionVerifierKt)
-class DependencyLockAlignmentLauncherSpec extends IntegrationTestKitSpec {
+class DependencyLockAlignmentLauncherSpec extends BaseIntegrationTestKitSpec {
     def setup() {
         definePluginOutsideOfPluginBlock = true
         keepFiles = true
+        disableConfigurationCache()
     }
 
     @Unroll

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockConfigurationAvoidanceSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockConfigurationAvoidanceSpec.groovy
@@ -1,5 +1,6 @@
 package nebula.plugin.dependencylock
 
+import nebula.plugin.BaseIntegrationTestKitSpec
 import nebula.plugin.dependencylock.tasks.CommitLockTask
 import nebula.plugin.dependencylock.tasks.DiffLockTask
 import nebula.plugin.dependencylock.tasks.GenerateLockTask
@@ -7,10 +8,9 @@ import nebula.plugin.dependencylock.tasks.MigrateLockedDepsToCoreLocksTask
 import nebula.plugin.dependencylock.tasks.MigrateToCoreLocksTask
 import nebula.plugin.dependencylock.tasks.SaveLockTask
 import nebula.plugin.dependencylock.tasks.UpdateLockTask
-import nebula.test.IntegrationTestKitSpec
 
 
-class DependencyLockConfigurationAvoidanceSpec extends IntegrationTestKitSpec {
+class DependencyLockConfigurationAvoidanceSpec extends BaseIntegrationTestKitSpec {
     def 'task configuration avoidance'() {
         given:
         buildFile << """\

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginIntegrationSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginIntegrationSpec.groovy
@@ -1,9 +1,9 @@
 package nebula.plugin.dependencylock
 
+import nebula.plugin.BaseIntegrationTestKitSpec
 import nebula.plugin.dependencylock.dependencyfixture.Fixture
-import nebula.test.IntegrationSpec
 
-class DependencyLockPluginIntegrationSpec extends IntegrationSpec {
+class DependencyLockPluginIntegrationSpec extends BaseIntegrationTestKitSpec {
     def setupSpec() {
         Fixture.createFixtureIfNotCreated()
     }
@@ -33,10 +33,10 @@ class DependencyLockPluginIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
 
         when:
-        def result = runTasksSuccessfully('dependencies')
+        def result = runTasks('dependencies')
 
         then:
-        result.standardOutput.contains('\\--- test.example:foo:latest.release -> 1.0.1\n')
+        result.output.contains('\\--- test.example:foo:latest.release -> 1.0.1\n')
     }
 
     def 'able to modify configuration in beforeResolve block'() {
@@ -67,10 +67,10 @@ class DependencyLockPluginIntegrationSpec extends IntegrationSpec {
             """.stripIndent()
 
         when:
-        def result = runTasksSuccessfully('dependencies')
+        def result = runTasks('dependencies')
 
         then:
-        result.standardOutput.contains('+--- test.example:foo:latest.release -> 1.0.0\n')
-        result.standardOutput.contains('\\--- test.example:bar:latest.release -> 1.0.0\n')
+        result.output.contains('+--- test.example:foo:latest.release -> 1.0.0\n')
+        result.output.contains('\\--- test.example:bar:latest.release -> 1.0.0\n')
     }
 }

--- a/src/test/groovy/nebula/plugin/dependencylock/GlobalLockLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/GlobalLockLauncherSpec.groovy
@@ -13,17 +13,17 @@
  */
 package nebula.plugin.dependencylock
 
-
-import nebula.test.IntegrationTestKitSpec
+import nebula.plugin.BaseIntegrationTestKitSpec
 import nebula.test.dependencies.DependencyGraphBuilder
 import nebula.test.dependencies.GradleDependencyGenerator
 import nebula.test.dependencies.ModuleBuilder
 
-class GlobalLockLauncherSpec extends IntegrationTestKitSpec {
+class GlobalLockLauncherSpec extends BaseIntegrationTestKitSpec {
 
     def setup() {
         definePluginOutsideOfPluginBlock = true
         keepFiles = true
+        disableConfigurationCache()
     }
 
     def 'global lock selective dependency updates'() {

--- a/src/test/groovy/nebula/plugin/dependencylock/PathAwareDependencyDiffSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/PathAwareDependencyDiffSpec.groovy
@@ -1,8 +1,8 @@
 package nebula.plugin.dependencylock
 
 import groovy.json.JsonSlurper
+import nebula.plugin.BaseIntegrationTestKitSpec
 import nebula.plugin.dependencylock.util.LockGenerator
-import nebula.test.IntegrationTestKitSpec
 import nebula.test.dependencies.DependencyGraph
 import nebula.test.dependencies.DependencyGraphBuilder
 import nebula.test.dependencies.GradleDependencyGenerator
@@ -11,7 +11,7 @@ import nebula.test.dependencies.maven.Pom
 import nebula.test.dependencies.maven.ArtifactType
 import nebula.test.dependencies.repositories.MavenRepo
 
-class PathAwareDependencyDiffSpec extends IntegrationTestKitSpec {
+class PathAwareDependencyDiffSpec extends BaseIntegrationTestKitSpec {
 
     private File repoDir
 

--- a/src/test/groovy/nebula/plugin/dependencylock/ResolutionRulesLockabilitySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/ResolutionRulesLockabilitySpec.groovy
@@ -18,8 +18,8 @@
 
 package nebula.plugin.dependencylock
 
+import nebula.plugin.BaseIntegrationTestKitSpec
 import nebula.plugin.dependencylock.util.LockGenerator
-import nebula.test.IntegrationTestKitSpec
 import org.gradle.testkit.runner.TaskOutcome
 
 import java.util.jar.Attributes
@@ -27,7 +27,7 @@ import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
 
-class ResolutionRulesLockabilitySpec extends IntegrationTestKitSpec {
+class ResolutionRulesLockabilitySpec extends BaseIntegrationTestKitSpec {
     def mavenForRules
 
     def setup() {
@@ -94,6 +94,8 @@ class ResolutionRulesLockabilitySpec extends IntegrationTestKitSpec {
     }
 
     def 'global locking works'() {
+        disableConfigurationCache()
+
         when:
         def result = runTasks('generateGlobalLock', 'saveGlobalLock')
 

--- a/src/test/groovy/nebula/plugin/dependencylock/caching/AbstractCachingAndDependencyLockingFeatureFlagsSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/caching/AbstractCachingAndDependencyLockingFeatureFlagsSpec.groovy
@@ -22,6 +22,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.junit.Stubbing
+import nebula.plugin.BaseIntegrationTestKitSpec
 import nebula.test.IntegrationTestKitSpec
 import nebula.test.dependencies.DependencyGraph
 import nebula.test.dependencies.DependencyGraphBuilder
@@ -30,7 +31,7 @@ import nebula.test.dependencies.ModuleBuilder
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.ProvideSystemProperty
 
-class AbstractCachingAndDependencyLockingFeatureFlagsSpec extends IntegrationTestKitSpec {
+class AbstractCachingAndDependencyLockingFeatureFlagsSpec extends BaseIntegrationTestKitSpec {
     static WireMockServer wireMockServer
     static WireMock testClient
     static Stubbing wm

--- a/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
+++ b/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
@@ -18,7 +18,7 @@
 
 package nebula.plugin.dependencyverifier
 
-import nebula.test.IntegrationTestKitSpec
+import nebula.plugin.BaseIntegrationTestKitSpec
 import nebula.test.dependencies.DependencyGraphBuilder
 import nebula.test.dependencies.GradleDependencyGenerator
 import nebula.test.dependencies.ModuleBuilder
@@ -28,7 +28,7 @@ import spock.lang.Subject
 import spock.lang.Unroll
 
 @Subject(DependencyResolutionVerifierKt)
-class DependencyResolutionVerifierTest extends IntegrationTestKitSpec {
+class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
     def mavenrepo
 
     def setup() {
@@ -45,6 +45,7 @@ class DependencyResolutionVerifierTest extends IntegrationTestKitSpec {
 
         def transitiveNotAvailableDep = new File(mavenrepo.getMavenRepoDir(), "transitive/not/available/a")
         transitiveNotAvailableDep.deleteDir() // to create a missing transitive dependency
+        disableConfigurationCache() // DependencyResolutionVerifier does not support config cache
     }
 
     @Unroll
@@ -390,42 +391,7 @@ class DependencyResolutionVerifierTest extends IntegrationTestKitSpec {
         where:
         tasks << [['build'], ['build', '--parallel']]
     }
-
-    @IgnoreIf({ jvm.isJava17Compatible() })
-    @Unroll
-    def 'with Gradle version #gradleVersionToTest - expecting #expecting'() {
-        given:
-        gradleVersion = gradleVersionToTest
-        setupSingleProject()
-
-        if (expecting == 'error') {
-            buildFile << """
-                dependencies {
-                    implementation 'not.available:a:1.0.0' // dependency is not found
-                }
-                """.stripIndent()
-        }
-
-        when:
-        def results
-        def tasks = ['dependencies', '--configuration', 'compileClasspath']
-
-        if (expecting == 'error') {
-            results = runTasksAndFail(*tasks)
-        } else {
-            results = runTasks(*tasks)
-        }
-
-        then:
-        results.output.contains('Task :dependencies')
-
-        where:
-        gradleVersionToTest | expecting
-        '6.9'               | 'error'
-        '6.9'               | 'no error'
-        '6.0.1'             | 'error'
-        '6.0.1'             | 'no error'
-    }
+    
 
     @Unroll
     def 'handles task configuration issue due to #failureType'() {
@@ -1165,55 +1131,6 @@ class DependencyResolutionVerifierTest extends IntegrationTestKitSpec {
         assert results.output.contains('> Task :included-project:sub1:dependencies')
         assert results.output.contains("1. Failed to resolve 'not.available:b:1.0.0' for project 'sub1'")
         assert results.output.contains('FAIL')
-    }
-
-    @IgnoreIf({ jvm.isJava17Compatible() })
-    @Unroll
-    def 'with Gradle version #gradleVersionToTest - expecting #expecting - using task with configuration dependencies'() {
-        given:
-        gradleVersion = gradleVersionToTest
-        setupSingleProject()
-
-        buildFile << taskThatRequiresConfigurationDependencies()
-
-        if (expecting == 'error') {
-            buildFile << """
-                dependencies {
-                    implementation 'not.available:a:1.0.0' // dependency is not found
-                }
-                """.stripIndent()
-        }
-
-        when:
-        def results
-        def tasks = ['dependencies', '--configuration', 'compileClasspath']
-
-        if (expecting == 'error') {
-            results = runTasksAndFail(*tasks)
-        } else {
-            results = runTasks(*tasks)
-        }
-
-        then:
-        if (expecting == 'error') {
-            assert results.output.contains('Execution failed for task \':taskWithConfigurationDependencies\'')
-            assert results.output.contains("1. Failed to resolve 'not.available:a:1.0.0' for project")
-        } else {
-            assert results.output.contains('Task :dependencies')
-        }
-
-        where:
-        gradleVersionToTest | expecting
-        '6.0.1'             | 'error'
-        '6.0.1'             | 'no error'
-        '5.6.4'             | 'error'
-        '5.6.4'             | 'no error'
-        '5.1'               | 'error'
-        '5.1'               | 'no error'
-        '4.10.3'            | 'error'
-        '4.10.3'            | 'no error'
-        '4.9'               | 'error'
-        '4.9'               | 'no error'
     }
 
     private static String taskThatRequiresConfigurationDependencies() {


### PR DESCRIPTION
This marks the tasks as not config cache compatible but also introduces usage of the new `BuildFeatures` api. Let's make a major release for this as it requires 8.5+