### PR TITLE
Do not lock configurations ending in DependenciesMetadata

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
@@ -106,6 +106,7 @@ class GenerateLockTask extends AbstractLockTask {
                     it.canBeResolved && !ConfigurationFilters.safelyHasAResolutionAlternative(it) &&
                             // Always exclude compileOnly and build tools configurations to avoid issues with kotlin plugin
                             !it.name.endsWith("CompileOnly") &&
+                            !it.name.endsWith("DependenciesMetadata") &&
                             it.name != "compileOnly" &&
                             it.name != "kotlinBuildToolsApiClasspath"
                 }


### PR DESCRIPTION
These may not be implementing 'isCanBeResolved' correctly, so we call them out

See related issues:
- https://youtrack.jetbrains.com/issue/KT-34394/
- https://github.com/tehlers/gradle-download-dependencies-plugin/pull/4