### PR TITLE
Modernization, Phase 6 Part 2: Dependency Resolution Verifier configuration cache compatibility

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
@@ -15,8 +15,7 @@
  */
 package nebula.plugin.dependencylock.tasks
 
-import nebula.plugin.dependencylock.DependencyLockExtension
-import nebula.plugin.dependencylock.DependencyLockTaskConfigurer
+
 import nebula.plugin.dependencylock.DependencyLockWriter
 import nebula.plugin.dependencylock.exceptions.DependencyLockException
 import nebula.plugin.dependencylock.model.LockKey
@@ -44,7 +43,6 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
-import org.gradle.internal.deprecation.DeprecationLogger
 import org.gradle.work.DisableCachingByDefault
 
 @DisableCachingByDefault
@@ -90,8 +88,6 @@ abstract class GenerateLockTask extends AbstractLockTask {
     @Internal
     abstract Property<Boolean> getDependencyLockIgnored()
 
-    // Official Gradle Resolution APIs (Approach 1)
-    // Captures dependency graphs using Gradle's official APIs instead of Configuration objects
     @Input
     abstract MapProperty<String, Provider<ResolvedComponentResult>> getResolutionResults()
 
@@ -235,7 +231,7 @@ abstract class GenerateLockTask extends AbstractLockTask {
 
     class GenerateLockFromConfigurations {
         /**
-         * Generate lock file using Gradle's official Resolution API (NEW API - Configuration Cache Compatible).
+         * Generate lock file using Gradle's official Resolution API
          * @param resolutionMap Map of configuration name to Provider<ResolvedComponentResult>
          * @param peerCoordinates List of peer project coordinates in "group:name" format
          * @return Map of LockKey to LockValue

--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/MigrateLockedDepsToCoreLocksTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/MigrateLockedDepsToCoreLocksTask.groovy
@@ -43,7 +43,6 @@ abstract class MigrateLockedDepsToCoreLocksTask extends AbstractMigrateToCoreLoc
 
     @TaskAction
     void migrateLockedDependencies() {
-        //TODO: address Invocation of Task.project at execution time has been deprecated.
         DeprecationLogger.whileDisabled {
             if (DependencyLockingFeatureFlags.isCoreLockingEnabled()) {
                 def coreLockingHelper = new CoreLockingHelper(project)

--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/MigrateToCoreLocksTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/MigrateToCoreLocksTask.groovy
@@ -36,7 +36,6 @@ abstract class MigrateToCoreLocksTask extends AbstractMigrateToCoreLocksTask {
 
     @TaskAction
     void migrateUnlockedDependencies() {
-        //TODO: address Invocation of Task.project at execution time has been deprecated.
         DeprecationLogger.whileDisabled {
             if (DependencyLockingFeatureFlags.isCoreLockingEnabled()) {
                 def coreLockingHelper = new CoreLockingHelper(project)

--- a/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 Netflix, Inc.
+ * Copyright 2014-2026 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,49 +18,32 @@ package nebula.plugin.dependencyverifier
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 
-/**
- * Extension for configuring dependency resolution verification.
- * Uses Gradle's Property API for lazy configuration and configuration cache compatibility.
- */
+/** Extension for dependency resolution verification (Property API, config-cache friendly). */
 abstract class DependencyResolutionVerifierExtension {
-    /**
-     * Whether to fail the build when verification issues are found.
-     * Default: true
-     */
+    /** Fail the build when verification finds issues. Default: true */
     abstract Property<Boolean> getShouldFailTheBuild()
-    
-    /**
-     * Configuration names to exclude from verification.
-     * Default: empty set
-     */
+
+    /** Configuration names to exclude from verification. Default: empty set */
     abstract SetProperty<String> getConfigurationsToExclude()
-    
-    /**
-     * Additional message to append when missing versions are detected.
-     * Default: empty string
-     */
+
+    /** Message to append when missing versions are detected. Default: empty */
     abstract Property<String> getMissingVersionsMessageAddition()
-    
-    /**
-     * Additional message to append when resolved version doesn't match locked version.
-     * Default: empty string
-     */
+
+    /** Message to append when resolved version does not match locked. Default: empty */
     abstract Property<String> getResolvedVersionDoesNotEqualLockedVersionMessageAddition()
-    
-    /**
-     * Task names to exclude from verification.
-     * Default: empty set
-     */
+
+    /** Task names to exclude from verification. Default: empty set */
     abstract SetProperty<String> getTasksToExclude()
-    
-    /**
-     * Constructor sets default conventions for all properties.
-     */
+
+    /** When true (default): full lock validation. When false: only resolution errors, config cache compatible. */
+    abstract Property<Boolean> getEnableLockFileValidation()
+
     DependencyResolutionVerifierExtension() {
         shouldFailTheBuild.convention(true)
         configurationsToExclude.convention([] as Set)
         missingVersionsMessageAddition.convention('')
         resolvedVersionDoesNotEqualLockedVersionMessageAddition.convention('')
         tasksToExclude.convention([] as Set)
+        enableLockFileValidation.convention(true)
     }
 }

--- a/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyResolutionErrorFormatter.kt
+++ b/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyResolutionErrorFormatter.kt
@@ -1,0 +1,109 @@
+/**
+ *
+ *  Copyright 2026 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package nebula.plugin.dependencyverifier
+
+/** Shared formatter for dependency resolution error messages (task and FlowAction). */
+object DependencyResolutionErrorFormatter {
+
+    private const val UNRESOLVED_HEADER = "Failed to resolve the following dependencies:"
+    private const val LOCK_MISMATCH_HEADER = "Dependency lock state is out of date:"
+    private const val LOCK_UPDATE_HINT = "Please update your dependency locks or your build file constraints."
+    private const val MISSING_VERSION_PREFIX = "The following dependencies are missing a version: "
+    private const val MISSING_VERSION_BOM_HINT = "Please add a version to fix this. If you have been using a BOM, perhaps these dependencies are no longer managed."
+
+    /** Format unresolved dependency coordinates (e.g. from BuildService failure map keys) into a numbered message. */
+    fun formatUnresolvedDependencies(
+        deps: Collection<String>,
+        projectName: String,
+        missingVersionsAddition: String = ""
+    ): String {
+        val sorted = deps.sorted()
+        val main = formatUnresolvedDepsList(sorted, projectName)
+        val missingVersion = sorted.filter { it.split(':').size < 3 }
+        if (missingVersion.isEmpty()) return main
+        val sb = StringBuilder(main)
+        sb.append("\n\n")
+        sb.append(MISSING_VERSION_PREFIX)
+        sb.append(missingVersion.joinToString(", "))
+        sb.append("\n")
+        sb.append(MISSING_VERSION_BOM_HINT)
+        if (missingVersionsAddition.isNotEmpty()) {
+            sb.append(" ")
+            sb.append(missingVersionsAddition)
+        }
+        sb.append("\n")
+        return sb.toString()
+    }
+
+    /** Format lock version mismatches (mismatch desc -> configs) with optional custom message. */
+    fun formatLockMismatches(
+        mismatches: Map<String, Set<String>>,
+        projectName: String,
+        customMessage: String = ""
+    ): String {
+        val messages = mutableListOf<String>()
+        messages.add(LOCK_MISMATCH_HEADER)
+        var counter = 1
+        mismatches.toSortedMap().forEach { (mismatchDesc, configs) ->
+            messages.add("  $counter. Resolved $mismatchDesc for project '$projectName' for configuration(s): ${configs.joinToString(",")}")
+            counter++
+        }
+        messages.add("")
+        messages.add(LOCK_UPDATE_HINT)
+        if (customMessage.isNotEmpty()) {
+            messages.add(customMessage)
+        }
+        return messages.joinToString("\n")
+    }
+
+    /** Extract dependency coordinates from resolution exception messages (used by engine). */
+    fun extractUnresolvedDependenciesFromException(exceptionMessage: String): Set<String> {
+        val dependencies = mutableSetOf<String>()
+        extractCoordsFromCouldNotFind(exceptionMessage, dependencies)
+        extractCoordsFromWasNotFound(exceptionMessage, dependencies)
+        extractCoordsFromGenericTriple(exceptionMessage, dependencies)
+        return dependencies
+    }
+
+    private fun formatUnresolvedDepsList(deps: List<String>, projectName: String): String {
+        val lines = mutableListOf(UNRESOLVED_HEADER)
+        deps.forEachIndexed { index, dep ->
+            lines.add("  ${index + 1}. Failed to resolve '$dep' for project '$projectName'")
+        }
+        return lines.joinToString("\n")
+    }
+
+    /** Matches "Could not find group:name:version" (Gradle-style resolution errors). */
+    private fun extractCoordsFromCouldNotFind(message: String, out: MutableSet<String>) {
+        Regex("""Could not find ([^:\s]+:[^:\s]+:[^:\s,\.\)]+)""").findAll(message).forEach { out.add(it.groupValues[1]) }
+    }
+
+    /** Matches "group:name:version was not found" (alternative phrasing). */
+    private fun extractCoordsFromWasNotFound(message: String, out: MutableSet<String>) {
+        Regex("""([^:\s]+:[^:\s]+:[^:\s,\.\)]+) was not found""").findAll(message).forEach { out.add(it.groupValues[1]) }
+    }
+
+    /** Matches any group:name:version-looking triple (fallback); filters out noise. */
+    private fun extractCoordsFromGenericTriple(message: String, out: MutableSet<String>) {
+        Regex("""([a-zA-Z0-9._-]+:[a-zA-Z0-9._-]+:[a-zA-Z0-9._-]+)""").findAll(message).forEach { match ->
+            val coord = match.groupValues[1]
+            if (coord.contains(".") || coord.split(":").all { it.isNotEmpty() }) out.add(coord)
+        }
+    }
+}

--- a/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyResolutionFlowAction.kt
+++ b/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyResolutionFlowAction.kt
@@ -1,0 +1,88 @@
+/**
+ *
+ *  Copyright 2026 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package nebula.plugin.dependencyverifier
+
+import org.gradle.api.flow.FlowAction
+import org.gradle.api.flow.FlowParameters
+import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.api.tasks.Input
+
+/**
+ * Runs after the build and reports verification failures when the requested tasks were reporting-only
+ * (e.g. `dependencies`, `dependencyInsight`, `dependenciesForAll`).
+ * Reads failures and lock mismatches from [DependencyVerificationBuildService] and fails or logs accordingly.
+ *
+ * Two paths: (1) Normal builds — [DependencyVerificationTask] throws or logs immediately when it runs.
+ * (2) Reporting-only builds — the task does not report (throwOnFailures = false); this FlowAction runs
+ * after the build and performs the fail or log using BuildService state.
+ *
+ * Parameters mirror [VerifierParameters] (shouldFailTheBuild, messages, taskNames) but must stay flat:
+ * FlowAction Parameters do not support [org.gradle.api.tasks.Nested], so we cannot reuse [VerifierParameters] here.
+ */
+abstract class DependencyResolutionFlowAction : FlowAction<DependencyResolutionFlowAction.Parameters> {
+
+    private val logger = Logging.getLogger(DependencyResolutionFlowAction::class.java)
+
+    /**
+     * Flat parameters required because FlowAction does not support [org.gradle.api.tasks.Nested].
+     * Subset of [VerifierParameters] needed for post-build reporting (no resolution/lock data).
+     */
+    interface Parameters : FlowParameters {
+        @get:Input
+        val projectKey: Property<String>
+        @get:Input
+        val projectName: Property<String>
+        @get:Input
+        val shouldFailTheBuild: Property<Boolean>
+        @get:Input
+        val lockMismatchMessage: Property<String>
+        @get:Input
+        val missingVersionsMessageAddition: Property<String>
+        @get:Input
+        val requestedTaskNames: org.gradle.api.provider.ListProperty<String>
+        @get:Input
+        val buildResult: Property<org.gradle.api.flow.BuildWorkResult>
+        @get:ServiceReference("dependencyVerificationService")
+        val verificationService: Property<DependencyVerificationBuildService>
+    }
+
+    override fun execute(parameters: Parameters) {
+        if (!ReportingTasks.isReportingTasksOnly(parameters.requestedTaskNames.get())) return
+        if (parameters.buildResult.get().failure.isPresent) return
+        val service = parameters.verificationService.get()
+        val projKey = parameters.projectKey.get()
+        val projName = parameters.projectName.get()
+        val failBuild = parameters.shouldFailTheBuild.get()
+        val failures = service.getFailuresForProject(projKey)
+        val mismatches = service.getMismatchedVersionsForProject(projKey)
+
+        VerifierFailureReporter.reportFailuresAndMismatches(
+            failures,
+            mismatches,
+            projName,
+            parameters.missingVersionsMessageAddition.get(),
+            parameters.lockMismatchMessage.get(),
+            failBuild,
+            throwOnFailures = true,
+            logger
+        )
+    }
+}

--- a/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyVerificationBuildService.kt
+++ b/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyVerificationBuildService.kt
@@ -1,0 +1,79 @@
+/**
+ *
+ *  Copyright 2026 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package nebula.plugin.dependencyverifier
+
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import java.util.Collections
+import java.util.HashMap
+import java.util.HashSet
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Tracks verification state across projects; config-cache compatible, thread-safe.
+ * State is cleared per project at the start of each build when [initializeProject] is called,
+ * so the service does not leak stale failures across builds in the same daemon.
+ * Uses only Java collection types for per-dependency sets (Collections.synchronizedSet(HashSet()), not
+ * ConcurrentHashMap.newKeySet()) so the service is safe in Gradle workers (no kotlin.collections export).
+ */
+abstract class DependencyVerificationBuildService : BuildService<DependencyVerificationBuildService.Params> {
+
+    interface Params : BuildServiceParameters
+
+    val failedDepsPerProject: ConcurrentHashMap<String, ConcurrentHashMap<String, MutableSet<String>>> = ConcurrentHashMap()
+    val depsWhereResolvedVersionIsNotLockedVersion: ConcurrentHashMap<String, ConcurrentHashMap<String, MutableSet<String>>> = ConcurrentHashMap()
+
+    fun recordFailedDependency(projectKey: String, dependency: String, configurationName: String) {
+        failedDepsPerProject.computeIfAbsent(projectKey) { ConcurrentHashMap() }
+            .computeIfAbsent(dependency) { Collections.synchronizedSet(HashSet()) }
+            .add(configurationName)
+    }
+
+    fun recordMismatchedVersion(projectKey: String, key: String, configurationName: String) {
+        depsWhereResolvedVersionIsNotLockedVersion.computeIfAbsent(projectKey) { ConcurrentHashMap() }
+            .computeIfAbsent(key) { Collections.synchronizedSet(HashSet()) }
+            .add(configurationName)
+    }
+
+    fun getFailuresForProject(projectKey: String): Map<String, Set<String>> {
+        val map = failedDepsPerProject[projectKey] ?: return emptyMap()
+        val result = HashMap<String, Set<String>>()
+        map.forEach { (k, v) -> result[k] = HashSet(v) }
+        return result
+    }
+
+    fun getMismatchedVersionsForProject(projectKey: String): Map<String, Set<String>> {
+        val map = depsWhereResolvedVersionIsNotLockedVersion[projectKey] ?: return emptyMap()
+        val result = HashMap<String, Set<String>>()
+        map.forEach { (k, v) -> result[k] = HashSet(v) }
+        return result
+    }
+
+    fun clearProject(projectKey: String) {
+        failedDepsPerProject.remove(projectKey)
+        depsWhereResolvedVersionIsNotLockedVersion.remove(projectKey)
+    }
+
+    /** Clears any existing state for this project and prepares fresh state for the current build. */
+    fun initializeProject(projectKey: String) {
+        clearProject(projectKey)
+        failedDepsPerProject[projectKey] = ConcurrentHashMap()
+        depsWhereResolvedVersionIsNotLockedVersion[projectKey] = ConcurrentHashMap()
+    }
+}

--- a/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyVerificationTask.kt
+++ b/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyVerificationTask.kt
@@ -1,0 +1,98 @@
+/**
+ *
+ *  Copyright 2026 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package nebula.plugin.dependencyverifier
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+
+@DisableCachingByDefault
+abstract class DependencyVerificationTask : DefaultTask() {
+
+    /**
+     * Injected by Gradle because this task is registered with [org.gradle.api.Task.usesService] and the
+     * name matches the build service registered in the plugin. At execution time [verify] uses it to
+     * build a [VerificationSink] that forwards to this service.
+     */
+    @get:ServiceReference("dependencyVerificationService")
+    abstract val verificationService: Property<DependencyVerificationBuildService>
+
+    @get:Nested
+    abstract val parameters: VerifierParameters
+
+    init {
+        outputs.doNotCacheIf("Verification task with no file outputs") { true }
+        outputs.upToDateWhen { false }
+        description = "Verifies that all dependencies can be resolved and match lock files"
+        group = "verification"
+    }
+
+    @TaskAction
+    fun verify() {
+        val projName = parameters.projectName.get()
+        val projKey = parameters.projectKey.get()
+        val resolutionResultsMap = parameters.resolutionResults.get()
+        if (resolutionResultsMap.isEmpty()) return
+
+        val service = verificationService.get()
+        val sink = object : VerificationSink {
+            override fun recordFailedDependency(projectKey: String, dependency: String, configurationName: String) {
+                service.recordFailedDependency(projectKey, dependency, configurationName)
+            }
+            override fun recordMismatchedVersion(projectKey: String, key: String, configurationName: String) {
+                service.recordMismatchedVersion(projectKey, key, configurationName)
+            }
+        }
+
+        val lockValidationEnabled = parameters.enableLockFileValidation.get() &&
+            parameters.coreAlignmentEnabled.get() &&
+            !parameters.coreLockingEnabled.get() &&
+            !parameters.taskNames.get().any { it.contains("updateLock") || it.contains("generateLock") }
+        val lockedDepsMap = parameters.lockedDependenciesPerConfiguration.get()
+        val overrideDepsMap = parameters.overrideDependenciesPerConfiguration.get()
+
+        VerificationEngine.run(
+            resolutionResultsMap,
+            sink,
+            projKey,
+            lockValidationEnabled,
+            lockedDepsMap,
+            overrideDepsMap
+        )
+
+        val failures = service.getFailuresForProject(projKey)
+        val mismatchedVersions = service.getMismatchedVersionsForProject(projKey)
+        val shouldFail = parameters.shouldFailTheBuild.get()
+        val throwOnFailures = shouldFail && !parameters.reportingOnlyBuild.get()
+
+        VerifierFailureReporter.reportFailuresAndMismatches(
+            failures,
+            mismatchedVersions,
+            projName,
+            parameters.missingVersionsMessageAddition.get(),
+            parameters.resolvedVersionDoesNotEqualLockedVersionMessageAddition.get(),
+            shouldFail,
+            throwOnFailures,
+            logger
+        )
+    }
+}

--- a/src/main/kotlin/nebula/plugin/dependencyverifier/ReportingTasks.kt
+++ b/src/main/kotlin/nebula/plugin/dependencyverifier/ReportingTasks.kt
@@ -1,0 +1,70 @@
+/**
+ *
+ *  Copyright 2026 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package nebula.plugin.dependencyverifier
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.diagnostics.DependencyInsightReportTask
+import org.gradle.api.tasks.diagnostics.DependencyReportTask
+
+/**
+ * Shared logic for detecting reporting-only builds (dependency report tasks that show but do not fail on resolution errors).
+ *
+ * **When to use which overload:**
+ * - Use [isReportingTasksOnly] with [Project] during configuration when the task container is available (e.g. in [DependencyResolutionVerifier]).
+ * - Use [isReportingTasksOnly] with task names when [Project] is not available (e.g. in [DependencyResolutionFlowAction] after build, or any config-cache-safe context).
+ *
+ * **Limitation:** The name-based overload only recognizes [REPORTING_TASK_NAMES]. Custom tasks that extend [DependencyReportTask] or [DependencyInsightReportTask] but use a different task name are not recognized by the name-based check and will be treated as non-reporting.
+ */
+object ReportingTasks {
+
+    /**
+     * Task names treated as reporting-only by the name-based overload.
+     * Align with Gradle's default names: `dependencies`, `dependencyInsight`, and the common `dependenciesForAll` convention.
+     * Custom report task names must be added here to be recognized when using [isReportingTasksOnly] with task names.
+     */
+    internal val REPORTING_TASK_NAMES: Set<String> = setOf("dependencies", "dependencyInsight", "dependenciesForAll")
+
+    /**
+     * Returns true if all requested tasks are reporting types (DependencyReportTask, DependencyInsightReportTask).
+     * Use this overload during configuration when [Project] and the task container are available.
+     * Uses task lookup by path; not configuration-cache compatible (eager API).
+     */
+    fun isReportingTasksOnly(project: Project): Boolean {
+        val taskNames = project.gradle.startParameter.taskNames
+        if (taskNames.isEmpty()) return false
+        val taskContainer = project.rootProject.tasks
+        return taskNames.all { path ->
+            val task = taskContainer.findByPath(path)
+            task != null && (task is DependencyReportTask || task is DependencyInsightReportTask)
+        }
+    }
+
+    /**
+     * Returns true if all requested task names match [REPORTING_TASK_NAMES] (by simple name, after the last ':').
+     * Use this overload when [Project] is not available (e.g. in FlowAction after build) or when configuration-cache safety is required.
+     * Does not recognize custom report tasks whose names are not in [REPORTING_TASK_NAMES].
+     */
+    fun isReportingTasksOnly(taskNames: List<String>): Boolean {
+        if (taskNames.isEmpty()) return false
+        return taskNames.all { taskName ->
+            val simpleName = taskName.substringAfterLast(':')
+            REPORTING_TASK_NAMES.contains(simpleName)
+        }
+    }
+}

--- a/src/main/kotlin/nebula/plugin/dependencyverifier/ResolvedArtifactData.kt
+++ b/src/main/kotlin/nebula/plugin/dependencyverifier/ResolvedArtifactData.kt
@@ -1,0 +1,38 @@
+/**
+ *
+ *  Copyright 2026 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package nebula.plugin.dependencyverifier
+
+import java.io.Serializable
+
+/**
+ * Data about a successfully resolved artifact.
+ * Used for comparing with lock file versions (in DependencyVerificationTask).
+ */
+data class ResolvedArtifactData(
+    /** Group (e.g. com.example) */
+    val group: String,
+    /** Module name (e.g. artifact) */
+    val module: String,
+    /** Resolved version (e.g. 1.0.0) */
+    val version: String
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/src/main/kotlin/nebula/plugin/dependencyverifier/VerificationEngine.kt
+++ b/src/main/kotlin/nebula/plugin/dependencyverifier/VerificationEngine.kt
@@ -1,0 +1,125 @@
+/**
+ *
+ *  Copyright 2026 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package nebula.plugin.dependencyverifier
+
+import org.gradle.api.artifacts.ResolveException
+import org.gradle.api.artifacts.component.ComponentIdentifier
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.artifacts.result.ResolvedDependencyResult
+import org.gradle.api.logging.Logging
+import org.gradle.api.provider.Provider
+
+/**
+ * Pure verification logic: one graph traversal, optional lock validation, records via sink.
+ * No Gradle task/service types so the engine is easy to test and reuse.
+ */
+object VerificationEngine {
+
+    private val logger = Logging.getLogger(VerificationEngine::class.java)
+
+    /**
+     * Runs resolution verification and optional lock validation.
+     * Single traversal per configuration: collects unresolved deps and resolved coordinates.
+     * Records failures and mismatches to [sink].
+     */
+    fun run(
+        resolutionResultsMap: Map<String, Provider<ResolvedComponentResult>>,
+        sink: VerificationSink,
+        projectKey: String,
+        lockValidationEnabled: Boolean,
+        lockedDepsMap: Map<String, Map<String, String>>,
+        overrideDepsMap: Map<String, Map<String, String>>
+    ) {
+        val resolvedPerConf = mutableMapOf<String, List<ResolvedArtifactData>>()
+        for ((confName, rootProvider) in resolutionResultsMap) {
+            try {
+                val root = rootProvider.get()
+                val unresolved = mutableSetOf<String>()
+                val resolved = mutableListOf<ResolvedArtifactData>()
+                traverse(root, mutableSetOf(), unresolved, resolved)
+                unresolved.forEach { sink.recordFailedDependency(projectKey, it, confName) }
+                resolvedPerConf[confName] = resolved
+            } catch (e: ResolveException) {
+                logger.debug("Resolution failed for configuration '$confName': ${e.message}", e)
+                val messages = collectMessagesFromCauses(e.causes)
+                val deps = DependencyResolutionErrorFormatter.extractUnresolvedDependenciesFromException(messages.joinToString(" | "))
+                deps.forEach { sink.recordFailedDependency(projectKey, it, confName) }
+            } catch (e: Exception) {
+                logger.debug("Resolution failed for configuration '$confName': ${e.message}", e)
+                val messages = mutableListOf<String>()
+                var t: Throwable? = e
+                while (t != null) {
+                    t.message?.let { messages.add(it) }
+                    t = t.cause
+                }
+                val deps = DependencyResolutionErrorFormatter.extractUnresolvedDependenciesFromException(messages.joinToString(" | "))
+                deps.forEach { sink.recordFailedDependency(projectKey, it, confName) }
+            }
+        }
+        if (!lockValidationEnabled || lockedDepsMap.isEmpty()) return
+        for ((confName, artifacts) in resolvedPerConf) {
+            val locked = lockedDepsMap.getOrDefault(confName, emptyMap())
+            val overrides = overrideDepsMap.getOrDefault(confName, emptyMap())
+            if (locked.isEmpty() && overrides.isEmpty()) continue
+            for (a in artifacts) {
+                val key = "${a.group}:${a.module}"
+                val expected = overrides[key]?.takeIf { it.isNotEmpty() } ?: locked[key]?.takeIf { it.isNotEmpty() } ?: ""
+                if (expected.isNotEmpty() && expected != a.version) {
+                    val mismatchKey = "'${a.group}:${a.module}:${a.version}' instead of locked version '$expected'"
+                    sink.recordMismatchedVersion(projectKey, mismatchKey, confName)
+                }
+            }
+        }
+    }
+
+    /** Collects exception messages from ResolveException.getCauses() and each cause's chain. */
+    private fun collectMessagesFromCauses(causes: Iterable<Throwable>): List<String> {
+        val messages = mutableListOf<String>()
+        for (cause in causes) {
+            var t: Throwable? = cause
+            while (t != null) {
+                t.message?.let { messages.add(it) }
+                t = t.cause
+            }
+        }
+        return messages
+    }
+
+    private fun traverse(
+        component: ResolvedComponentResult,
+        visited: MutableSet<ComponentIdentifier>,
+        unresolved: MutableSet<String>,
+        resolved: MutableList<ResolvedArtifactData>
+    ) {
+        if (!visited.add(component.id)) return
+        val id = component.id
+        if (id is ModuleComponentIdentifier) {
+            resolved.add(ResolvedArtifactData(group = id.group, module = id.module, version = id.version))
+        }
+        component.dependencies.forEach { dep ->
+            when (dep) {
+                is org.gradle.api.artifacts.result.UnresolvedDependencyResult ->
+                    unresolved.add(dep.requested.displayName)
+                is ResolvedDependencyResult ->
+                    traverse(dep.selected, visited, unresolved, resolved)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/nebula/plugin/dependencyverifier/VerificationSink.kt
+++ b/src/main/kotlin/nebula/plugin/dependencyverifier/VerificationSink.kt
@@ -1,0 +1,28 @@
+/**
+ *
+ *  Copyright 2026 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package nebula.plugin.dependencyverifier
+
+/**
+ * Sink for verification results so the engine stays independent of BuildService.
+ * The task forwards these to DependencyVerificationBuildService.
+ */
+interface VerificationSink {
+    fun recordFailedDependency(projectKey: String, dependency: String, configurationName: String)
+    fun recordMismatchedVersion(projectKey: String, key: String, configurationName: String)
+}

--- a/src/main/kotlin/nebula/plugin/dependencyverifier/VerifierFailureReporter.kt
+++ b/src/main/kotlin/nebula/plugin/dependencyverifier/VerifierFailureReporter.kt
@@ -1,0 +1,68 @@
+/**
+ *
+ *  Copyright 2026 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package nebula.plugin.dependencyverifier
+
+import nebula.plugin.dependencyverifier.exceptions.DependencyResolutionException
+import org.gradle.api.logging.Logger
+
+/**
+ * Shared failure reporting so [DependencyVerificationTask] and [DependencyResolutionFlowAction]
+ * use one place for "format then throw or log" logic.
+ *
+ * @param throwOnFailures When true, throw or log for both resolution failures and lock mismatches.
+ * When false (e.g. task in reporting-only build), do nothing so [DependencyResolutionFlowAction] can report later.
+ */
+object VerifierFailureReporter {
+
+    fun reportFailuresAndMismatches(
+        failures: Map<String, Set<String>>,
+        mismatches: Map<String, Set<String>>,
+        projectName: String,
+        missingVersionsAddition: String,
+        lockMismatchMessage: String,
+        shouldFailTheBuild: Boolean,
+        throwOnFailures: Boolean,
+        logger: Logger
+    ) {
+        if (failures.isNotEmpty() && throwOnFailures) {
+            val msg = DependencyResolutionErrorFormatter.formatUnresolvedDependencies(
+                failures.keys,
+                projectName,
+                missingVersionsAddition
+            )
+            if (shouldFailTheBuild) {
+                throw DependencyResolutionException(msg)
+            } else {
+                logger.warn("Unresolved dependencies:\n$msg")
+            }
+        }
+        if (mismatches.isNotEmpty() && throwOnFailures) {
+            val msg = DependencyResolutionErrorFormatter.formatLockMismatches(
+                mismatches,
+                projectName,
+                lockMismatchMessage
+            )
+            if (shouldFailTheBuild) {
+                throw DependencyResolutionException(msg)
+            } else {
+                logger.warn(msg)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/nebula/plugin/dependencyverifier/VerifierTaskParameters.kt
+++ b/src/main/kotlin/nebula/plugin/dependencyverifier/VerifierTaskParameters.kt
@@ -1,0 +1,76 @@
+/**
+ *
+ *  Copyright 2026 Netflix, Inc.
+ *
+ *     Licensed under the Apache License, Version 2.0 (the "License");
+ *     you may not use this file except in compliance with the License.
+ *     You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License.
+ *
+ */
+
+package nebula.plugin.dependencyverifier
+
+import org.gradle.api.artifacts.result.ResolvedComponentResult
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+
+/** All inputs to the verification task (project identity, behavior options, lock data, resolution results). */
+abstract class VerifierParameters {
+
+    @get:Input
+    abstract val projectKey: Property<String>
+
+    @get:Input
+    abstract val projectName: Property<String>
+
+    @get:Input
+    abstract val shouldFailTheBuild: Property<Boolean>
+
+    @get:Input
+    abstract val missingVersionsMessageAddition: Property<String>
+
+    @get:Input
+    abstract val resolvedVersionDoesNotEqualLockedVersionMessageAddition: Property<String>
+
+    @get:Input
+    abstract val configurationsToExclude: SetProperty<String>
+
+    @get:Input
+    abstract val enableLockFileValidation: Property<Boolean>
+
+    @get:Input
+    abstract val configurationNamesToValidate: ListProperty<String>
+
+    @get:Input
+    abstract val taskNames: ListProperty<String>
+
+    @get:Input
+    abstract val reportingOnlyBuild: Property<Boolean>
+
+    @get:Input
+    abstract val coreAlignmentEnabled: Property<Boolean>
+
+    @get:Input
+    abstract val coreLockingEnabled: Property<Boolean>
+
+    @get:Input
+    abstract val lockedDependenciesPerConfiguration: MapProperty<String, Map<String, String>>
+
+    @get:Input
+    abstract val overrideDependenciesPerConfiguration: MapProperty<String, Map<String, String>>
+
+    @get:Internal
+    abstract val resolutionResults: MapProperty<String, org.gradle.api.provider.Provider<ResolvedComponentResult>>
+}

--- a/src/test/groovy/nebula/plugin/BaseIntegrationTestKitSpec.groovy
+++ b/src/test/groovy/nebula/plugin/BaseIntegrationTestKitSpec.groovy
@@ -5,7 +5,10 @@ import nebula.test.IntegrationTestKitSpec
 abstract class BaseIntegrationTestKitSpec extends IntegrationTestKitSpec {
     def setup() {
         // Enable configuration cache to make sure we don't break builds
-        new File(projectDir, 'gradle.properties') << '''org.gradle.configuration-cache=true'''.stripIndent()
+        new File(projectDir, 'gradle.properties') << '''
+            org.gradle.configuration-cache=true
+            org.gradle.warning.mode=fail
+            '''.stripIndent()
     }
 
     void disableConfigurationCache() {

--- a/src/test/groovy/nebula/plugin/VerifierOutputAssertionsBase.groovy
+++ b/src/test/groovy/nebula/plugin/VerifierOutputAssertionsBase.groovy
@@ -17,6 +17,10 @@ abstract class VerifierOutputAssertionsBase {
             ('verifyDependencyResolution' + FAILED_SUFFIX),
             FAILED_RESOLVE_FOLLOWING
     ]
+    protected static final List<String> CONFIG_CACHE_STORING_ERROR_MESSAGES = [
+            "Configuration cache state could not be cached",
+            "problem was found storing the configuration cache"
+    ]
 
     static void assertResolutionFailureMessage(String resultsOutput) {
         assert RESOLUTION_FAILURE_MARKERS.any { resultsOutput.contains(it) },
@@ -60,6 +64,25 @@ abstract class VerifierOutputAssertionsBase {
             assert hasProjectContextInOutput(resultsOutput, name),
                 "Expected output to mention project '$name'"
         }
+    }
+
+    static void assertConfigurationCacheStateCouldNotBeStored(String resultsOutput) {
+        assert CONFIG_CACHE_STORING_ERROR_MESSAGES.any { resultsOutput.contains(it) },
+                "Expected configuration cache state could not be stored. Looked for but did not find: '${CONFIG_CACHE_STORING_ERROR_MESSAGES.join("', '")}'"
+    }
+
+    static void assertNoConfigurationCacheStoringIssues(String resultsOutput) {
+        assert CONFIG_CACHE_STORING_ERROR_MESSAGES.every { !resultsOutput.contains(it) },
+                "Expected _not_ to see configuration cache storing issues, but found: '${CONFIG_CACHE_STORING_ERROR_MESSAGES.join("', '")}'"
+
+        def entryStoredMessage = "Configuration cache entry stored."
+        assert resultsOutput.contains(entryStoredMessage),
+                "Expected to see configuration cache entry stored, but found: '${entryStoredMessage}'"
+    }
+
+    static void assertConfigurationCachingIsNotMentioned(String resultsOutput) {
+        assert CONFIG_CACHE_STORING_ERROR_MESSAGES.every { !resultsOutput.contains(it) },
+                "Expected configuration caching to _not_ be mentioned, but found: '${CONFIG_CACHE_STORING_ERROR_MESSAGES.join("', '")}'"
     }
 
     protected static boolean hasResolutionFailureForDependency(String resultsOutput, String dependency) {

--- a/src/test/groovy/nebula/plugin/dependencylock/AbstractDependencyLockPluginSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/AbstractDependencyLockPluginSpec.groovy
@@ -17,7 +17,11 @@ class AbstractDependencyLockPluginSpec extends BaseIntegrationTestKitSpec {
     def projectName
 
     def setup() {
-        new File("${projectDir}/gradle.properties").text = "systemProp.nebula.features.coreLockingSupport=true"
+        new File(projectDir, 'gradle.properties').text = '''
+            org.gradle.configuration-cache=true
+            systemProp.nebula.features.coreLockingSupport=true
+            org.gradle.warning.mode=fail
+            '''.stripIndent()
 
         projectName = getProjectDir().getName().replaceAll(/_\d+/, '')
         settingsFile << """\

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockCommitLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockCommitLauncherSpec.groovy
@@ -56,12 +56,15 @@ class DependencyLockCommitLauncherSpec extends IntegrationSpec implements Global
 build/
 gradle.properties'''.stripIndent()
 
-        // Enable configuration cache :)
-        new File(projectDir, 'gradle.properties') << '''org.gradle.configuration-cache=true'''.stripIndent()
         def gradleProperties = new File(projectDir, "gradle.properties")
         gradleProperties.createNewFile()
-        gradleProperties << "systemProp.nebula.features.coreLockingSupport=false"
 
+        // Enable configuration cache :)
+        gradleProperties << '''
+            org.gradle.configuration-cache=true
+            org.gradle.warning.mode=fail
+            systemProp.nebula.features.coreLockingSupport=false
+            '''.stripIndent()
 
         git.commit(message: 'Setup')
         git.push()
@@ -130,6 +133,9 @@ gradle.properties'''.stripIndent()
     }
 
     def 'git integration test for global lock on multiproject'() {
+        def gradleProperties = new File(projectDir, "gradle.properties")
+        gradleProperties.text = gradleProperties.text.replace('org.gradle.configuration-cache=true', 'org.gradle.configuration-cache=false')
+
         def sub1 = new File(projectDir, 'sub1')
         sub1.mkdirs()
         def sub2 = new File(projectDir, 'sub2')

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockConfigurationAvoidanceSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockConfigurationAvoidanceSpec.groovy
@@ -1,6 +1,5 @@
 package nebula.plugin.dependencylock
 
-import spock.lang.Ignore
 import nebula.plugin.BaseIntegrationTestKitSpec
 import nebula.plugin.GlobalLockDeprecations
 import nebula.plugin.dependencylock.tasks.CommitLockTask
@@ -244,6 +243,7 @@ class DependencyLockConfigurationAvoidanceSpec extends BaseIntegrationTestKitSpe
         gradleProperties.text = '''
             systemProp.nebula.features.coreLockingSupport=true
             org.gradle.configuration-cache=true
+            org.gradle.warning.mode=fail
         '''.stripIndent()
         
         buildFile << """
@@ -284,6 +284,7 @@ class DependencyLockConfigurationAvoidanceSpec extends BaseIntegrationTestKitSpe
         gradleProperties.text = '''
             systemProp.nebula.features.coreLockingSupport=true
             org.gradle.configuration-cache=true
+            org.gradle.warning.mode=fail
         '''.stripIndent()
         
         buildFile << """

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreSpec.groovy
@@ -414,6 +414,9 @@ class DependencyLockPluginWithCoreSpec extends AbstractDependencyLockPluginSpec 
         'implementation' | 'compileClasspath'
     }
 
+    // Kotlin plugin in a subproject only causes configuration-cache serialization failure (FUS/build service
+    // classloader mismatch). Declare with apply false at root so the plugin is in the same classloader scope.
+    // See: https://github.com/gradle/gradle/issues/31278
     @Unroll
     def 'generate core lock file with kotlin plugin with multiproject setup - for configuration #configuration'() {
         given:
@@ -423,6 +426,7 @@ class DependencyLockPluginWithCoreSpec extends AbstractDependencyLockPluginSpec 
         buildFile << """\
             plugins {
                 id 'com.netflix.nebula.dependency-lock'
+                id "org.jetbrains.kotlin.jvm" version "2.2.0" apply false
             }
             allprojects {
                 task dependenciesForAll(type: DependencyReportTask) {}
@@ -436,7 +440,7 @@ class DependencyLockPluginWithCoreSpec extends AbstractDependencyLockPluginSpec 
         addSubproject("sub1", """
             plugins {
                 id 'com.netflix.nebula.dependency-lock'
-                id "org.jetbrains.kotlin.jvm" version "2.2.0"
+                id "org.jetbrains.kotlin.jvm"
             }
             dependencies {
                 $configuration 'test.nebula:a:1.+'

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreVerifierSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockPluginWithCoreVerifierSpec.groovy
@@ -10,6 +10,7 @@ import spock.lang.IgnoreIf
 import spock.lang.Subject
 import spock.lang.Unroll
 
+import static nebula.plugin.VerifierOutputAssertionsBase.assertConfigurationCachingIsNotMentioned
 import static nebula.plugin.VerifierOutputAssertionsBase.assertResolutionFailureForDependencyForProject
 import static nebula.plugin.dependencylock.DependencyLockPluginWithCoreVerifierSpec.OutputAssertions.assertExecutionFailedForTask
 import static nebula.plugin.dependencylock.DependencyLockPluginWithCoreVerifierSpec.OutputAssertions.assertLockStateFailure
@@ -63,6 +64,7 @@ empty=annotationProcessor,testAnnotationProcessor
 
         then:
         results.output.contains('FAILURE')
+        assertConfigurationCachingIsNotMentioned(results.output)
 
         where:
         lockArg << ['write-locks', 'update-locks']
@@ -102,6 +104,7 @@ empty=annotationProcessor,testAnnotationProcessor
 
         then:
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertLockStateFailure(results.output, 'test.nebula:d:1.0.0')
     }
 
@@ -118,6 +121,7 @@ empty=annotationProcessor,testAnnotationProcessor
 
         then:
         results.output.contains('FAILURE')
+        assertConfigurationCachingIsNotMentioned(results.output)
 
         where:
         lockArg << ['write-locks', 'update-locks']
@@ -149,6 +153,7 @@ empty=annotationProcessor,testAnnotationProcessor
 
         then:
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertLockStateFailure(results.output, 'test.nebula:d:1.0.0', 'sub1')
     }
 
@@ -164,6 +169,7 @@ empty=annotationProcessor,testAnnotationProcessor
 
         then:
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertResolutionFailureMessage(results.output)
         assertUnresolvedDependenciesInOutput(results.output, MIX_UNRESOLVABLE_DEPENDENCY_COORDINATES)
 
@@ -184,6 +190,7 @@ empty=annotationProcessor,testAnnotationProcessor
 
         then:
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertResolutionFailureMessage(results.output)
         assertUnresolvedDependenciesInOutput(results.output, MIX_UNRESOLVABLE_DEPENDENCY_COORDINATES, 'sub1')
 
@@ -201,7 +208,7 @@ empty=annotationProcessor,testAnnotationProcessor
         when:
         buildFile << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
 
-        runTasksAndFail(*tasks(lockArg))
+        def results = runTasksAndFail(*tasks(lockArg))
 
         then:
         def secondRunLockfile = new File(projectDir, 'gradle.lockfile')
@@ -209,6 +216,8 @@ empty=annotationProcessor,testAnnotationProcessor
                 "empty=annotationProcessor,testAnnotationProcessor",
                 "test.nebula:d:1.0.0=compileClasspath,runtimeClasspath\nempty=annotationProcessor,testAnnotationProcessor"
         )
+        results.output.contains('FAILURE')
+        assertConfigurationCachingIsNotMentioned(results.output)
 
         where:
         lockArg << ['write-locks', 'update-locks']
@@ -225,7 +234,7 @@ empty=annotationProcessor,testAnnotationProcessor
         new File(projectDir, 'sub1/build.gradle') << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
         new File(projectDir, 'sub2/build.gradle') << MIX_OF_RESOLVABLE_AND_UNRESOLVABLE_DEPENDENCIES
 
-        runTasksAndFail(*tasks(lockArg, true))
+        def results = runTasksAndFail(*tasks(lockArg, true))
 
         then:
         def secondRunLockfile = new File(projectDir, 'sub1/gradle.lockfile')
@@ -233,6 +242,9 @@ empty=annotationProcessor,testAnnotationProcessor
                 "empty=annotationProcessor,testAnnotationProcessor",
                 "test.nebula:d:1.0.0=compileClasspath,runtimeClasspath\nempty=annotationProcessor,testAnnotationProcessor"
         )
+
+        results.output.contains('FAILURE')
+        assertConfigurationCachingIsNotMentioned(results.output)
 
         where:
         lockArg << ['write-locks', 'update-locks']
@@ -251,6 +263,7 @@ empty=annotationProcessor,testAnnotationProcessor
 
         then:
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertResolutionFailureForDependencyForProject(results.output, 'not.available:a:1.0.0', "sub1")
         assertResolutionFailureForDependencyForProject(results.output, 'not.available:a:1.0.0', "sub2")
         assertOutputMentionsProjects(results.output, ['sub1', 'sub2'])
@@ -275,6 +288,7 @@ empty=annotationProcessor,testAnnotationProcessor
 
         then:
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertResolutionFailureForDependencyForProject(results.output, 'not.available:a:1.0.0', 'sub1')
         assertResolutionFailureForDependencyForProject(results.output, 'not.available:a:1.0.0', 'sub2')
         assertOutputMentionsProjects(results.output, ['sub1', 'sub2'])
@@ -297,6 +311,7 @@ empty=annotationProcessor,testAnnotationProcessor
 
         then:
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertResolutionFailureMessage(results.output)
         assertUnresolvedDependenciesInOutput(results.output, MIX_UNRESOLVABLE_DEPENDENCY_COORDINATES)
 
@@ -318,6 +333,7 @@ empty=annotationProcessor,testAnnotationProcessor
 
         then:
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertUnresolvedDependenciesInOutput(results.output, MIX_UNRESOLVABLE_DEPENDENCY_COORDINATES)
 
         where:
@@ -336,6 +352,7 @@ empty=annotationProcessor,testAnnotationProcessor
 
         then:
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertUnresolvedDependenciesInOutput(results.output, MIX_UNRESOLVABLE_DEPENDENCY_COORDINATES)
 
         where:
@@ -354,6 +371,7 @@ empty=annotationProcessor,testAnnotationProcessor
 
         then:
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertUnresolvedDependenciesInOutput(results.output, MIX_UNRESOLVABLE_DEPENDENCY_COORDINATES)
 
         where:
@@ -374,6 +392,7 @@ empty=annotationProcessor,testAnnotationProcessor
 
         then:
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertUnresolvedDependenciesInOutput(results.output, MIX_UNRESOLVABLE_DEPENDENCY_COORDINATES)
 
         where:

--- a/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
+++ b/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
@@ -27,8 +27,11 @@ import spock.lang.Ignore
 import spock.lang.Subject
 import spock.lang.Unroll
 
+import static nebula.plugin.VerifierOutputAssertionsBase.assertConfigurationCachingIsNotMentioned
+import static nebula.plugin.VerifierOutputAssertionsBase.assertConfigurationCacheStateCouldNotBeStored
 import static nebula.plugin.dependencyverifier.DependencyResolutionVerifierTest.OutputAssertions.assertExecutionFailedForTask
 import static nebula.plugin.dependencyverifier.DependencyResolutionVerifierTest.OutputAssertions.assertFailureMessageIsDisplayedOnce
+import static nebula.plugin.dependencyverifier.DependencyResolutionVerifierTest.OutputAssertions.assertNoConfigurationCacheStoringIssues
 import static nebula.plugin.dependencyverifier.DependencyResolutionVerifierTest.OutputAssertions.assertNoResolutionFailureMessage
 import static nebula.plugin.dependencyverifier.DependencyResolutionVerifierTest.OutputAssertions.assertResolutionFailureForDependency
 import static nebula.plugin.dependencyverifier.DependencyResolutionVerifierTest.OutputAssertions.assertResolutionFailureForDependencyForProject
@@ -55,7 +58,6 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
 
         def transitiveNotAvailableDep = new File(mavenrepo.getMavenRepoDir(), "transitive/not/available/a")
         transitiveNotAvailableDep.deleteDir() // to create a missing transitive dependency
-        disableConfigurationCache() // DependencyResolutionVerifier does not support config cache
     }
 
     @Unroll
@@ -68,6 +70,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
 
         then:
         !results.output.contains('FAILURE')
+        assertNoConfigurationCacheStoringIssues(results.output)
 
         where:
         tasks                                                   | description
@@ -91,6 +94,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
         assertResolutionFailureMessage(results.output)
         assertResolutionFailureForDependency(results.output, "not.available:a:1.0.0")
 
@@ -116,6 +120,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertResolutionFailureMessage(results.output)
         assertResolutionFailureForDependency(results.output, "not.available:a:1.0.0")
 
@@ -141,6 +146,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
         assertResolutionFailureMessage(results.output)
         assertResolutionFailureForDependency(results.output, "transitive.not.available:a:1.0.0")
 
@@ -166,6 +172,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertResolutionFailureMessage(results.output)
         assertResolutionFailureForDependency(results.output, "transitive.not.available:a:1.0.0")
 
@@ -192,6 +199,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
         assertResolutionFailureMessage(results.output)
         assertResolutionFailureForMissingVersionDependencies(results.output, ["test.nebula:c", "test.nebula:d"])
 
@@ -218,6 +226,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertResolutionFailureMessage(results.output)
         assertResolutionFailureForMissingVersionDependencies(results.output, ["test.nebula:c", "test.nebula:d"])
 
@@ -243,6 +252,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
         assertResolutionFailureMessage(results.output)
         assertResolutionFailureForDependency(results.output, "junit:junit:999.99.9")
 
@@ -268,6 +278,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertResolutionFailureMessage(results.output)
         assertResolutionFailureForDependency(results.output, "junit:junit:999.99.9")
 
@@ -299,6 +310,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
         assertResolutionFailureMessage(results.output)
         assertResolutionFailureForDependencyForProject(results.output, "not.available:apricot:1.0.0", "sub1")
 
@@ -330,6 +342,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertResolutionFailureMessage(results.output)
         assertResolutionFailureForDependencyForProject(results.output, "not.available:apricot:1.0.0", "sub1")
 
@@ -384,6 +397,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
 
         then:
         !results.output.contains('FAILURE')
+        assertNoConfigurationCacheStoringIssues(results.output)
         !results.output.contains('was resolved without accessing the project in a safe manner')
 
         where:
@@ -437,6 +451,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
 
         then:
         !results.output.contains('FAILURE')
+        assertNoConfigurationCacheStoringIssues(results.output)
         !results.output.contains('was resolved without accessing the project in a safe manner')
 
         where:
@@ -467,6 +482,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
         assertResolutionFailureMessage(results.output)
         assertResolutionFailureForOneOfTheseDependencies(results.output, [
                 dependencyProjectPair("not.available:apricot:1.0.0", "sub1"),
@@ -501,6 +517,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
         assertResolutionFailureMessage(results.output)
         assertResolutionFailureForOneOfTheseDependencies(results.output, [
                 dependencyProjectPair("not.available:apricot:1.0.0", "sub1"),
@@ -542,6 +559,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
 
         then:
         !results.output.contains('FAILURE')
+        assertNoConfigurationCacheStoringIssues(results.output)
         assertNoResolutionFailureMessage(results.output)
 
         where:
@@ -617,6 +635,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
         assertResolutionFailureMessage(results.output)
         assertFailureMessageIsDisplayedOnce(results.output, "not.available:a")
 
@@ -764,6 +783,10 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         if (seeErrors) {
             assertResolutionFailureMessage(results.output)
             assertResolutionFailureForDependency(results.output, "not.available:a")
+            if (description == 'missingVersionsMessageAddition') {
+                assert results.output.contains('You can find additional help at...'),
+                        "Expected output to contain missingVersionsMessageAddition: 'You can find additional help at...'"
+            }
         } else {
             assertNoResolutionFailureMessage(results.output)
         }
@@ -774,6 +797,55 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         'extension.shouldFailTheBuild = false'                                            | 'shouldFailTheBuild'             | false    | true
         "list.addAll('myConfig')\n\textension.configurationsToExclude = list"             | 'configurationsToExclude'        | false    | false
         "list.addAll('dependencies')\n\textension.tasksToExclude = list"                  | 'tasksToExclude'                 | false    | false
+    }
+
+    def 'unresolved dependencies output includes missingVersionsMessageAddition when some dependencies lack a version'() {
+        given:
+        setupSingleProject()
+        def customAddition = 'Custom help: http://example.com/dependency-help'
+        buildFile << """
+            dependencies {
+                implementation 'not.available:a'
+            }
+            dependencyResolutionVerifierExtension {
+                missingVersionsMessageAddition = '$customAddition'
+            }
+        """.stripIndent()
+
+        when:
+        def results = runTasksAndFail('dependencies')
+
+        then:
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForDependency(results.output, 'not.available:a')
+        assert results.output.contains(customAddition),
+                "Expected output to contain missingVersionsMessageAddition: ${customAddition}"
+    }
+
+    def 'verifier skips configurations in the skip list (e.g. configurationsToExclude)'() {
+        given:
+        setupSingleProject()
+        new File(projectDir, 'gradle.properties') << """
+            dependencyResolutionVerifier.configurationsToExclude=skipMe
+        """.stripIndent()
+        buildFile << """
+            configurations {
+                skipMe {
+                    canBeResolved = true
+                }
+            }
+            dependencies {
+                skipMe 'not.available:unresolvable:1.0.0'
+            }
+        """.stripIndent()
+
+        when:
+        def results = runTasks('dependencies', '--configuration', 'compileClasspath')
+
+        then:
+        assert !results.output.toString().contains('FAILURE'):
+                "Verifier should skip skipMe via configurationsToExclude; without skip we would resolve it and fail"
+        assertNoConfigurationCacheStoringIssues(results.output)
     }
 
     def 'handles root and subproject of the same name'() {
@@ -800,6 +872,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
         assertResolutionFailureMessage(results.output)
         assertFailureMessageIsDisplayedOnce(results.output, "not.available:a:1.0.0")
         assertResolutionFailureForDependencyForProject(results.output, "not.available:a:1.0.0", "sub1")
@@ -826,6 +899,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
         assertResolutionFailureMessage(results.output)
         assertFailureMessageIsDisplayedOnce(results.output, "not.available:a:1.0.0")
         assertResolutionFailureForDependency(results.output, "not.available:a:1.0.0")
@@ -844,6 +918,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
 
         then:
         assert !results.output.contains('FAILURE')
+        assertNoConfigurationCacheStoringIssues(results.output)
     }
 
     @Unroll
@@ -902,6 +977,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         assert results.output.contains('FAILURE')
         assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
         assertResolutionFailureForDependencyForProject(results.output, actualMissingDep ?: dependency, "sub1")
         assert !results.output.contains("for project 'sub2'")
 
@@ -1377,24 +1453,29 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
             assert hasAResolutionFailureForDependency || verifierMessage, "Expected resolution failure or verifier missing-version message for ${missingList}"
         }
 
-        static void assertExecutionFailedForTask(String resultsOutput) {
-            List<String> taskFailureMarkers = [
-                    'Execution failed for task',
-                    'FAILURE: Build failed with an exception',
-                    'BUILD FAILED',
-                    FAILED_SUFFIX
-            ]
-            boolean fromMarkers = taskFailureMarkers.any { resultsOutput.contains(it) }
-            boolean fromBuildOutcome = resultsOutput.contains('Build completed with') && resultsOutput.contains('failure')
-            assert fromMarkers || fromBuildOutcome, 'Expected to see a message about a failure'
-        }
-
+        /**
+         * Asserts the resolution-failure message for this dependency appears exactly once in the output,
+         * to catch duplicate or spammed error reporting. Uses canonical verifier or Gradle phrasing and counts occurrences.
+         */
         static void assertFailureMessageIsDisplayedOnce(String resultsOutput, String dependency) {
             assert hasResolutionFailureForDependency(resultsOutput, dependency),
                     "Expected to see resolution failure for dependency '${dependency}'"
 
-            String onceBlock = RESOLUTION_FAILURE_MARKERS.last() + "\n  1. " + FAILED_RESOLVE_PREFIX + dependency + "' for project"
-            assert resultsOutput.findAll(onceBlock).size() == 1
+            String verifierExpectedText = """
+                > Failed to resolve the following dependencies:
+                1. $FAILED_RESOLVE_PREFIX '$dependency' for project
+                """.stripIndent()
+            String gradleExpectedText = "> " + COULD_NOT_FIND + dependency
+            int verifierCount = resultsOutput.findAll(verifierExpectedText).size()
+            int gradleCount = resultsOutput.findAll(gradleExpectedText).size()
+
+            if (verifierCount > 0) {
+                assert verifierCount == 1,
+                        "Resolution failure for '${dependency}' (verifier format) should appear exactly once, but appeared ${verifierCount} times"
+            } else if (gradleCount > 0) {
+                assert gradleCount == 1,
+                        "Resolution failure for '${dependency}' (Gradle format) should appear exactly once, but appeared ${gradleCount} times"
+            }
         }
 
         /**


### PR DESCRIPTION
The Dependency Resolution Verifier is now configuration-cache compatible.

- state lives in a shared `DependencyVerificationBuildService`
- a `DependencyVerificationTask` runs after compile/report tasks and records into it
- `DependencyResolutionFlowAction` runs after the build and reports (and optionally fails) for reporting-only builds. 

Verification is split into `VerificationEngine`, `DependencyResolutionErrorFormatter`, and `VerifierFailureReporter`. 

The Configurer resolves commit message, tag, includeTransitives, resolution map, and peer coordinates at configuration time

**Major changes:** 
- BuildService + task + FlowAction replace static maps and listeners; verification logic in testable units
- lock/commit inputs fixed at config time.

**Breaking changes:** None. Extension name string unchanged; internal constant typo fix only.

**Notable changes:** 
- new `enableLockFileValidation` (default true); reporting-only defers to FlowAction
- verifier registered in `afterEvaluate`
- global locking and migration tasks are still not config-cache compatible
