### PR TITLE
Stream lock files through Okio in DependencyLockReader.parseLockFile

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockReader.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockReader.groovy
@@ -98,9 +98,6 @@ class DependencyLockReader {
     }
 
     private static Map parseLockFile(File lock) {
-        // Stream via Okio rather than slurping the whole file into a String —
-        // for multi-MB lock files this avoids a duplicate UTF-16 copy on the
-        // heap and reduces peak memory under parallel module resolution.
         try {
             return lock.withInputStream { inputStream ->
                 JsonReader reader = JsonReader.of(Okio.buffer(Okio.source(inputStream)))
@@ -111,6 +108,9 @@ class DependencyLockReader {
                 }
             }
         } catch (ex) {
+            if (logger.isDebugEnabled()) {
+                logger.debug('Unreadable json file: ' + lock.text)
+            }
             logger.error("JSON unreadable: ${lock.absolutePath}")
             throw new GradleException("${lock.name} is unreadable or invalid json, terminating run", ex)
         }

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockReader.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockReader.groovy
@@ -1,10 +1,12 @@
 package nebula.plugin.dependencylock
 
 import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
 import com.squareup.moshi.Moshi
 import groovy.transform.TupleConstructor
 import nebula.plugin.dependencylock.model.LockKey
 import nebula.plugin.dependencylock.model.LockValue
+import okio.Okio
 import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -96,11 +98,20 @@ class DependencyLockReader {
     }
 
     private static Map parseLockFile(File lock) {
+        // Stream via Okio rather than slurping the whole file into a String —
+        // for multi-MB lock files this avoids a duplicate UTF-16 copy on the
+        // heap and reduces peak memory under parallel module resolution.
         try {
-            return jsonAdapter.fromJson(lock.text)
+            return lock.withInputStream { inputStream ->
+                JsonReader reader = JsonReader.of(Okio.buffer(Okio.source(inputStream)))
+                try {
+                    return jsonAdapter.fromJson(reader)
+                } finally {
+                    reader.close()
+                }
+            }
         } catch (ex) {
-            logger.debug('Unreadable json file: ' + lock.text)
-            logger.error('JSON unreadable')
+            logger.error("JSON unreadable: ${lock.absolutePath}")
             throw new GradleException("${lock.name} is unreadable or invalid json, terminating run", ex)
         }
     }


### PR DESCRIPTION
`DependencyLockReader.parseLockFile` reads each `dependencies.lock` via `lock.text`, which slurps the entire file into a Java `String` (UTF-16, ~2× file size on the heap) before Moshi parses it into a `Map`. For multi-MB lock files in large multi-module projects, this duplicate copy plus the parsed `Map` graph can push the Gradle daemon over its heap limit during parallel resolution, producing OOMs in `nebula.plugin.dependencylock.DependencyLockReader.parseLockFile` / `groovyFileGetText`.

Switch to `JsonReader.of(Okio.buffer(Okio.source(inputStream)))` so the file is decoded incrementally and only the parsed `Map` is retained. Okio is already a transitive dependency of Moshi.

Also gate the catch-handler's `lock.text` re-read behind `logger.isDebugEnabled()` — the previous unconditional debug-string concatenation evaluated `lock.text` even at default log levels, defeating the streaming win.

Behavior-preserving: same `JsonAdapter<Map>`, same returned `Map` shape; existing `DependencyLockReaderSpec` and `UpdateLockTaskSpec` pass unchanged.