### PR TITLE
Restore previous Extension APIs and also keep config-caching safe APIs available

### DIFF
--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
@@ -101,7 +101,7 @@ abstract class DependencyLockExtension {
     abstract SetProperty<String> getConfigurationNamesProperty()
 
     Set<String> getConfigurationNames() {
-        return configurationNamesProperty.get()
+        return new LinkedHashSet<>(configurationNamesProperty.get())
     }
 
     void setConfigurationNames(Iterable<String> values) {
@@ -120,7 +120,7 @@ abstract class DependencyLockExtension {
     abstract SetProperty<String> getSkippedConfigurationNamesPrefixesProperty()
 
     Set<String> getSkippedConfigurationNamesPrefixes() {
-        return skippedConfigurationNamesPrefixesProperty.get()
+        return new LinkedHashSet<>(skippedConfigurationNamesPrefixesProperty.get())
     }
 
     void setSkippedConfigurationNamesPrefixes(Iterable<String> values) {
@@ -147,7 +147,7 @@ abstract class DependencyLockExtension {
     abstract SetProperty<String> getUpdateDependenciesProperty()
 
     Set<String> getUpdateDependencies() {
-        return updateDependenciesProperty.get()
+        return new LinkedHashSet<>(updateDependenciesProperty.get())
     }
 
     void setUpdateDependencies(Iterable<String> values) {
@@ -166,7 +166,7 @@ abstract class DependencyLockExtension {
     abstract SetProperty<String> getSkippedDependenciesProperty()
 
     Set<String> getSkippedDependencies() {
-        return skippedDependenciesProperty.get()
+        return new LinkedHashSet<>(skippedDependenciesProperty.get())
     }
 
     void setSkippedDependencies(Iterable<String> values) {
@@ -274,7 +274,7 @@ abstract class DependencyLockExtension {
     abstract SetProperty<String> getAdditionalConfigurationsToLockProperty()
 
     Set<String> getAdditionalConfigurationsToLock() {
-        return additionalConfigurationsToLockProperty.get()
+        return new LinkedHashSet<>(additionalConfigurationsToLockProperty.get())
     }
 
     void setAdditionalConfigurationsToLock(Iterable<String> values) {

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
@@ -41,8 +41,20 @@ abstract class DependencyLockExtension {
      * Specific configuration names to lock.
      * If empty, all resolvable configurations will be locked.
      * Default: empty set
+     *
+     * The backing SetProperty is exposed via {@link #getConfigurationNamesProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old Set&lt;String&gt;
+     * API so existing build scripts continue to work without modification.
      */
-    abstract SetProperty<String> getConfigurationNames()
+    abstract SetProperty<String> getConfigurationNamesProperty()
+
+    Set<String> getConfigurationNames() {
+        return configurationNamesProperty.get()
+    }
+
+    void setConfigurationNames(Iterable<String> values) {
+        configurationNamesProperty.set(values)
+    }
 
     /**
      * Configuration name prefixes to skip when locking.
@@ -75,8 +87,20 @@ abstract class DependencyLockExtension {
      * Dependencies to update when running updateLock task.
      * Format: 'group:artifact'
      * Default: empty set
+     *
+     * The backing SetProperty is exposed via {@link #getUpdateDependenciesProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old Set&lt;String&gt;
+     * API so existing build scripts continue to work without modification.
      */
-    abstract SetProperty<String> getUpdateDependencies()
+    abstract SetProperty<String> getUpdateDependenciesProperty()
+
+    Set<String> getUpdateDependencies() {
+        return updateDependenciesProperty.get()
+    }
+
+    void setUpdateDependencies(Iterable<String> values) {
+        updateDependenciesProperty.set(values)
+    }
 
     /**
      * Dependencies to skip when generating locks.
@@ -130,8 +154,20 @@ abstract class DependencyLockExtension {
     /**
      * Additional configurations to lock beyond the standard set.
      * Default: empty set
+     *
+     * The backing SetProperty is exposed via {@link #getAdditionalConfigurationsToLockProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old Set&lt;String&gt;
+     * API so existing build scripts continue to work without modification.
      */
-    abstract SetProperty<String> getAdditionalConfigurationsToLock()
+    abstract SetProperty<String> getAdditionalConfigurationsToLockProperty()
+
+    Set<String> getAdditionalConfigurationsToLock() {
+        return additionalConfigurationsToLockProperty.get()
+    }
+
+    void setAdditionalConfigurationsToLock(Iterable<String> values) {
+        additionalConfigurationsToLockProperty.set(values)
+    }
 
     /**
      * Constructor sets default conventions for all properties.
@@ -139,16 +175,16 @@ abstract class DependencyLockExtension {
     DependencyLockExtension() {
         lockFile.convention('dependencies.lock')
         globalLockFile.convention('global.lock')
-        configurationNames.convention([] as Set)
+        configurationNamesProperty.convention([] as Set)
         skippedConfigurationNamesPrefixesProperty.convention([] as Set)
-        updateDependencies.convention([] as Set)
+        updateDependenciesProperty.convention([] as Set)
         skippedDependenciesProperty.convention([] as Set)
         includeTransitives.convention(false)
         lockAfterEvaluating.convention(true)
         updateDependenciesFailOnInvalidCoordinates.convention(true)
         updateDependenciesFailOnSimultaneousTaskUsage.convention(true)
         updateDependenciesFailOnNonSpecifiedDependenciesToUpdate.convention(true)
-        additionalConfigurationsToLock.convention([] as Set)
+        additionalConfigurationsToLockProperty.convention([] as Set)
     }
 
 }

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
@@ -24,25 +24,26 @@ import org.gradle.api.tasks.Internal
  * Uses Gradle's Property API for lazy configuration and configuration cache compatibility.
  */
 abstract class DependencyLockExtension {
+
     /**
      * Name of the lock file to generate.
      * Default: 'dependencies.lock'
      */
     abstract Property<String> getLockFile()
-    
+
     /**
      * Name of the global lock file.
      * Default: 'global.lock'
      */
     abstract Property<String> getGlobalLockFile()
-    
+
     /**
      * Specific configuration names to lock.
      * If empty, all resolvable configurations will be locked.
      * Default: empty set
      */
     abstract SetProperty<String> getConfigurationNames()
-    
+
     /**
      * Configuration name prefixes to skip when locking.
      * Default: empty set
@@ -56,56 +57,56 @@ abstract class DependencyLockExtension {
      */
     @Internal
     Closure dependencyFilter = { String group, String name, String version -> true }
-    
+
     /**
      * Dependencies to update when running updateLock task.
      * Format: 'group:artifact'
      * Default: empty set
      */
     abstract SetProperty<String> getUpdateDependencies()
-    
+
     /**
      * Dependencies to skip when generating locks.
      * Default: empty set
      */
     abstract SetProperty<String> getSkippedDependencies()
-    
+
     /**
      * Whether to include transitive dependencies in the lock file.
      * Default: false
      */
     abstract Property<Boolean> getIncludeTransitives()
-    
+
     /**
      * Whether to delay lock application until configuration resolution.
      * Default: true
      */
     abstract Property<Boolean> getLockAfterEvaluating()
-    
+
     /**
      * Whether to fail when invalid dependency coordinates are provided for updates.
      * Default: true
      */
     abstract Property<Boolean> getUpdateDependenciesFailOnInvalidCoordinates()
-    
+
     /**
      * Whether to fail when update tasks are used simultaneously with generate tasks.
      * Default: true
      */
     abstract Property<Boolean> getUpdateDependenciesFailOnSimultaneousTaskUsage()
-    
+
     /**
      * Whether to fail when non-specified dependencies need updates.
      * Default: true
      */
     abstract Property<Boolean> getUpdateDependenciesFailOnNonSpecifiedDependenciesToUpdate()
-    
+
     /**
      * Additional configurations to lock beyond the standard set.
      * Default: empty set
      */
     abstract SetProperty<String> getAdditionalConfigurationsToLock()
-    
+
     /**
      * Constructor sets default conventions for all properties.
      */
@@ -123,4 +124,5 @@ abstract class DependencyLockExtension {
         updateDependenciesFailOnNonSpecifiedDependenciesToUpdate.convention(true)
         additionalConfigurationsToLock.convention([] as Set)
     }
+
 }

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
@@ -55,14 +55,39 @@ abstract class DependencyLockExtension {
     /**
      * Name of the lock file to generate.
      * Default: 'dependencies.lock'
+     *
+     * The backing Property is exposed via {@link #getLockFileProperty()} for config-cache-compatible
+     * task wiring. The getter/setter here preserve the old {@code String} API so existing build
+     * scripts using {@code dependencyLock.lockFile = 'custom.lock'} or reading
+     * {@code dependencyLock.lockFile} as a plain String continue to work.
      */
-    abstract Property<String> getLockFile()
+    abstract Property<String> getLockFileProperty()
+
+    String getLockFile() {
+        return lockFileProperty.get()
+    }
+
+    void setLockFile(String value) {
+        lockFileProperty.set(value)
+    }
 
     /**
      * Name of the global lock file.
      * Default: 'global.lock'
+     *
+     * The backing Property is exposed via {@link #getGlobalLockFileProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old {@code String}
+     * API so existing build scripts continue to work without modification.
      */
-    abstract Property<String> getGlobalLockFile()
+    abstract Property<String> getGlobalLockFileProperty()
+
+    String getGlobalLockFile() {
+        return globalLockFileProperty.get()
+    }
+
+    void setGlobalLockFile(String value) {
+        globalLockFileProperty.set(value)
+    }
 
     /**
      * Specific configuration names to lock.
@@ -200,8 +225,8 @@ abstract class DependencyLockExtension {
      * Constructor sets default conventions for all properties.
      */
     DependencyLockExtension() {
-        lockFile.convention('dependencies.lock')
-        globalLockFile.convention('global.lock')
+        lockFileProperty.convention('dependencies.lock')
+        globalLockFileProperty.convention('global.lock')
         configurationNamesProperty.convention([] as Set)
         skippedConfigurationNamesPrefixesProperty.convention([] as Set)
         updateDependenciesProperty.convention([] as Set)

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
@@ -176,14 +176,38 @@ abstract class DependencyLockExtension {
     /**
      * Whether to include transitive dependencies in the lock file.
      * Default: false
+     *
+     * The backing Property is exposed via {@link #getIncludeTransitivesProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old {@code boolean}
+     * API so existing build scripts continue to work without modification.
      */
-    abstract Property<Boolean> getIncludeTransitives()
+    abstract Property<Boolean> getIncludeTransitivesProperty()
+
+    Boolean getIncludeTransitives() {
+        return includeTransitivesProperty.get()
+    }
+
+    void setIncludeTransitives(Boolean value) {
+        includeTransitivesProperty.set(value)
+    }
 
     /**
      * Whether to delay lock application until configuration resolution.
      * Default: true
+     *
+     * The backing Property is exposed via {@link #getLockAfterEvaluatingProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old {@code boolean}
+     * API so existing build scripts continue to work without modification.
      */
-    abstract Property<Boolean> getLockAfterEvaluating()
+    abstract Property<Boolean> getLockAfterEvaluatingProperty()
+
+    Boolean getLockAfterEvaluating() {
+        return lockAfterEvaluatingProperty.get()
+    }
+
+    void setLockAfterEvaluating(Boolean value) {
+        lockAfterEvaluatingProperty.set(value)
+    }
 
     /**
      * Whether to fail when invalid dependency coordinates are provided for updates.
@@ -231,8 +255,8 @@ abstract class DependencyLockExtension {
         skippedConfigurationNamesPrefixesProperty.convention([] as Set)
         updateDependenciesProperty.convention([] as Set)
         skippedDependenciesProperty.convention([] as Set)
-        includeTransitives.convention(false)
-        lockAfterEvaluating.convention(true)
+        includeTransitivesProperty.convention(false)
+        lockAfterEvaluatingProperty.convention(true)
         updateDependenciesFailOnInvalidCoordinates.convention(true)
         updateDependenciesFailOnSimultaneousTaskUsage.convention(true)
         updateDependenciesFailOnNonSpecifiedDependenciesToUpdate.convention(true)

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
@@ -212,20 +212,56 @@ abstract class DependencyLockExtension {
     /**
      * Whether to fail when invalid dependency coordinates are provided for updates.
      * Default: true
+     *
+     * The backing Property is exposed via {@link #getUpdateDependenciesFailOnInvalidCoordinatesProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old {@code boolean}
+     * API so existing build scripts continue to work without modification.
      */
-    abstract Property<Boolean> getUpdateDependenciesFailOnInvalidCoordinates()
+    abstract Property<Boolean> getUpdateDependenciesFailOnInvalidCoordinatesProperty()
+
+    Boolean getUpdateDependenciesFailOnInvalidCoordinates() {
+        return updateDependenciesFailOnInvalidCoordinatesProperty.get()
+    }
+
+    void setUpdateDependenciesFailOnInvalidCoordinates(Boolean value) {
+        updateDependenciesFailOnInvalidCoordinatesProperty.set(value)
+    }
 
     /**
      * Whether to fail when update tasks are used simultaneously with generate tasks.
      * Default: true
+     *
+     * The backing Property is exposed via {@link #getUpdateDependenciesFailOnSimultaneousTaskUsageProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old {@code boolean}
+     * API so existing build scripts continue to work without modification.
      */
-    abstract Property<Boolean> getUpdateDependenciesFailOnSimultaneousTaskUsage()
+    abstract Property<Boolean> getUpdateDependenciesFailOnSimultaneousTaskUsageProperty()
+
+    Boolean getUpdateDependenciesFailOnSimultaneousTaskUsage() {
+        return updateDependenciesFailOnSimultaneousTaskUsageProperty.get()
+    }
+
+    void setUpdateDependenciesFailOnSimultaneousTaskUsage(Boolean value) {
+        updateDependenciesFailOnSimultaneousTaskUsageProperty.set(value)
+    }
 
     /**
      * Whether to fail when non-specified dependencies need updates.
      * Default: true
+     *
+     * The backing Property is exposed via {@link #getUpdateDependenciesFailOnNonSpecifiedDependenciesToUpdateProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old {@code boolean}
+     * API so existing build scripts continue to work without modification.
      */
-    abstract Property<Boolean> getUpdateDependenciesFailOnNonSpecifiedDependenciesToUpdate()
+    abstract Property<Boolean> getUpdateDependenciesFailOnNonSpecifiedDependenciesToUpdateProperty()
+
+    Boolean getUpdateDependenciesFailOnNonSpecifiedDependenciesToUpdate() {
+        return updateDependenciesFailOnNonSpecifiedDependenciesToUpdateProperty.get()
+    }
+
+    void setUpdateDependenciesFailOnNonSpecifiedDependenciesToUpdate(Boolean value) {
+        updateDependenciesFailOnNonSpecifiedDependenciesToUpdateProperty.set(value)
+    }
 
     /**
      * Additional configurations to lock beyond the standard set.
@@ -257,9 +293,9 @@ abstract class DependencyLockExtension {
         skippedDependenciesProperty.convention([] as Set)
         includeTransitivesProperty.convention(false)
         lockAfterEvaluatingProperty.convention(true)
-        updateDependenciesFailOnInvalidCoordinates.convention(true)
-        updateDependenciesFailOnSimultaneousTaskUsage.convention(true)
-        updateDependenciesFailOnNonSpecifiedDependenciesToUpdate.convention(true)
+        updateDependenciesFailOnInvalidCoordinatesProperty.convention(true)
+        updateDependenciesFailOnSimultaneousTaskUsageProperty.convention(true)
+        updateDependenciesFailOnNonSpecifiedDependenciesToUpdateProperty.convention(true)
         additionalConfigurationsToLockProperty.convention([] as Set)
     }
 

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
@@ -302,16 +302,16 @@ abstract class DependencyLockExtension {
     DependencyLockExtension() {
         lockFileProperty.convention('dependencies.lock')
         globalLockFileProperty.convention('global.lock')
-        configurationNamesProperty.convention([] as Set)
-        skippedConfigurationNamesPrefixesProperty.convention([] as Set)
-        updateDependenciesProperty.convention([] as Set)
-        skippedDependenciesProperty.convention([] as Set)
+        configurationNamesProperty.convention([] as Set<String>)
+        skippedConfigurationNamesPrefixesProperty.convention([] as Set<String>)
+        updateDependenciesProperty.convention([] as Set<String>)
+        skippedDependenciesProperty.convention([] as Set<String>)
         includeTransitivesProperty.convention(false)
         lockAfterEvaluatingProperty.convention(true)
         updateDependenciesFailOnInvalidCoordinatesProperty.convention(true)
         updateDependenciesFailOnSimultaneousTaskUsageProperty.convention(true)
         updateDependenciesFailOnNonSpecifiedDependenciesToUpdateProperty.convention(true)
-        additionalConfigurationsToLockProperty.convention([] as Set)
+        additionalConfigurationsToLockProperty.convention([] as Set<String>)
     }
 
 }

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
@@ -68,8 +68,21 @@ abstract class DependencyLockExtension {
     /**
      * Dependencies to skip when generating locks.
      * Default: empty set
+     *
+     * The backing SetProperty is exposed via {@link #getSkippedDependenciesProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old Set&lt;String&gt;
+     * API so existing build scripts and plugins compiled against the previous version continue
+     * to work without modification.
      */
-    abstract SetProperty<String> getSkippedDependencies()
+    abstract SetProperty<String> getSkippedDependenciesProperty()
+
+    Set<String> getSkippedDependencies() {
+        return skippedDependenciesProperty.get()
+    }
+
+    void setSkippedDependencies(Iterable<String> values) {
+        skippedDependenciesProperty.set(values)
+    }
 
     /**
      * Whether to include transitive dependencies in the lock file.
@@ -116,7 +129,7 @@ abstract class DependencyLockExtension {
         configurationNames.convention([] as Set)
         skippedConfigurationNamesPrefixes.convention([] as Set)
         updateDependencies.convention([] as Set)
-        skippedDependencies.convention([] as Set)
+        skippedDependenciesProperty.convention([] as Set)
         includeTransitives.convention(false)
         lockAfterEvaluating.convention(true)
         updateDependenciesFailOnInvalidCoordinates.convention(true)

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
@@ -47,8 +47,21 @@ abstract class DependencyLockExtension {
     /**
      * Configuration name prefixes to skip when locking.
      * Default: empty set
+     *
+     * The backing SetProperty is exposed via {@link #getSkippedConfigurationNamesPrefixesProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old Set&lt;String&gt;
+     * API so existing build scripts and plugins compiled against the previous version continue
+     * to work without modification.
      */
-    abstract SetProperty<String> getSkippedConfigurationNamesPrefixes()
+    abstract SetProperty<String> getSkippedConfigurationNamesPrefixesProperty()
+
+    Set<String> getSkippedConfigurationNamesPrefixes() {
+        return skippedConfigurationNamesPrefixesProperty.get()
+    }
+
+    void setSkippedConfigurationNamesPrefixes(Iterable<String> values) {
+        skippedConfigurationNamesPrefixesProperty.set(values)
+    }
 
     /**
      * Filter closure for dependencies.
@@ -127,7 +140,7 @@ abstract class DependencyLockExtension {
         lockFile.convention('dependencies.lock')
         globalLockFile.convention('global.lock')
         configurationNames.convention([] as Set)
-        skippedConfigurationNamesPrefixes.convention([] as Set)
+        skippedConfigurationNamesPrefixesProperty.convention([] as Set)
         updateDependencies.convention([] as Set)
         skippedDependenciesProperty.convention([] as Set)
         includeTransitives.convention(false)

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
@@ -22,6 +22,33 @@ import org.gradle.api.tasks.Internal
 /**
  * Extension for configuring the dependency lock plugin.
  * Uses Gradle's Property API for lazy configuration and configuration cache compatibility.
+ *
+ * <h3>SetProperty backward-compat bridge convention</h3>
+ *
+ * Every {@code SetProperty<String>} field follows a two-name convention to satisfy two
+ * incompatible requirements simultaneously:
+ *
+ * <ol>
+ *   <li><b>Config-cache safety / lazy task wiring</b> — Gradle requires a {@code SetProperty}
+ *       (not a plain {@code Set}) to wire values into task parameters without resolving them at
+ *       configuration time. The abstract getter named {@code getFooProperty()} is the Gradle-managed
+ *       backing store used by internal plugin code for this purpose.</li>
+ *   <li><b>Backward-compatible Groovy DSL</b> — Before the {@code cd58be4 "modernize project"}
+ *       commit, all these fields were plain {@code Set<String>} properties. Hundreds of downstream
+ *       build scripts and plugins relied on Groovy property-assignment syntax
+ *       ({@code extension.foo = ['a', 'b']}) and on the getter returning a {@code Set<String>}.
+ *       Switching to {@code SetProperty} broke that syntax because Gradle does not generate a
+ *       {@code void setFoo(Iterable<String>)} setter for {@code SetProperty} fields — it only
+ *       generates {@code SetProperty<String> getFoo()}.  The concrete {@code Set<String> getFoo()}
+ *       getter and {@code void setFoo(Iterable<String>)} setter restore the old public API.</li>
+ * </ol>
+ *
+ * <p><b>Do not merge these two into one.</b> Removing the {@code *Property} getter breaks
+ * config-cache-safe task wiring. Removing the {@code Set<String>} getter/setter pair breaks
+ * downstream Groovy build scripts. Both sides of the bridge must be kept.</p>
+ *
+ * <p>Internal plugin code (tasks, configurers, helpers) always calls {@code fooProperty} directly.
+ * External callers (build scripts, third-party plugins) see only {@code foo} as a {@code Set<String>}.</p>
  */
 abstract class DependencyLockExtension {
 

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockExtension.groovy
@@ -15,6 +15,7 @@
  */
 package nebula.plugin.dependencylock
 
+import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Internal
@@ -129,11 +130,25 @@ abstract class DependencyLockExtension {
 
     /**
      * Filter closure for dependencies.
-     * Note: Closures are not configuration cache compatible, but this is kept for backward compatibility.
-     * Marked as @Internal so it doesn't affect task inputs.
+     *
+     * @deprecated Closures are not configuration-cache serializable. With CC enabled this field
+     * is silently dropped on a cache hit, reverting to the always-pass default and ignoring any
+     * custom filter you set. There is no CC-safe replacement yet; track
+     * https://github.com/nebula-plugins/gradle-dependency-lock-plugin/issues for updates.
+     * Marked @Internal so it does not affect task input fingerprints.
      */
+    @Deprecated
     @Internal
     Closure dependencyFilter = { String group, String name, String version -> true }
+
+    @SuppressWarnings('GrDeprecatedAPIUsage')
+    void setDependencyFilter(Closure filter) {
+        Logging.getLogger(DependencyLockExtension).warn(
+            'dependencyFilter is deprecated: Closures are not configuration-cache compatible ' +
+            'and will be silently ignored on a cache hit. See the plugin README for alternatives.'
+        )
+        this.dependencyFilter = filter
+    }
 
     /**
      * Dependencies to update when running updateLock task.

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockReader.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockReader.groovy
@@ -106,8 +106,9 @@ class DependencyLockReader {
     }
 
     private static Map parseLockFile(File lock) {
+        Map result
         try {
-            def result = lock.withInputStream { inputStream ->
+            result = lock.withInputStream { inputStream ->
                 JsonReader reader = JsonReader.of(Okio.buffer(Okio.source(inputStream)))
                 try {
                     return jsonAdapter.fromJson(reader)
@@ -115,7 +116,6 @@ class DependencyLockReader {
                     reader.close()
                 }
             }
-            return result != null ? result : [:]
         } catch (ex) {
             if (logger.isDebugEnabled()) {
                 try {
@@ -127,6 +127,11 @@ class DependencyLockReader {
             logger.error("JSON unreadable: ${lock.absolutePath}")
             throw new GradleException("${lock.name} is unreadable or invalid json, terminating run", ex)
         }
+        if (result == null) {
+            logger.error("JSON unreadable: ${lock.absolutePath}")
+            throw new GradleException("${lock.name} is unreadable or invalid json, terminating run")
+        }
+        return result
     }
 
 }

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockReader.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockReader.groovy
@@ -1,5 +1,8 @@
 package nebula.plugin.dependencylock
 
+import static DependencyLockTaskConfigurer.GLOBAL_LOCK_CONFIG
+import static DependencyLockTaskConfigurer.OVERRIDE_FILE
+
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.Moshi
@@ -12,11 +15,10 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
-import static DependencyLockTaskConfigurer.OVERRIDE_FILE
-import static DependencyLockTaskConfigurer.GLOBAL_LOCK_CONFIG
 
 @TupleConstructor
 class DependencyLockReader {
+
     private static final Logger logger = Logging.getLogger(DependencyLockReader)
     private static final Moshi moshi = new Moshi.Builder().build()
     private static final JsonAdapter<Map> jsonAdapter = moshi.adapter(Map)
@@ -29,8 +31,9 @@ class DependencyLockReader {
     Map readLocks(Configuration conf, File dependenciesLock, Map<LockKey, LockValue> requestedDependencies, Collection<String> updates = []) {
         logger.info("Using ${dependenciesLock.name} to lock dependencies in $conf")
 
-        if (!dependenciesLock.exists())
+        if (!dependenciesLock.exists()) {
             return null
+        }
 
         Map locks = parseLockFile(dependenciesLock)
 
@@ -42,7 +45,7 @@ class DependencyLockReader {
                 }
                 [(configurationName): deps.findAll { coord, info ->
                     def notUpdate = !updates.contains(coord)
-                    def coordinateSections = coord.split(":")
+                    def coordinateSections = coord.split(':')
                     def lockValue = requestedDependencies.get(new LockKey(group: coordinateSections[0], artifact: coordinateSections[1], configuration: configurationName)) ?: new LockValue()
                     def requestedAVersion = lockValue.requested != null
                     def isFirstLevel = info?.transitive == null
@@ -115,4 +118,5 @@ class DependencyLockReader {
             throw new GradleException("${lock.name} is unreadable or invalid json, terminating run", ex)
         }
     }
+
 }

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockReader.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockReader.groovy
@@ -102,7 +102,7 @@ class DependencyLockReader {
 
     private static Map parseLockFile(File lock) {
         try {
-            return lock.withInputStream { inputStream ->
+            def result = lock.withInputStream { inputStream ->
                 JsonReader reader = JsonReader.of(Okio.buffer(Okio.source(inputStream)))
                 try {
                     return jsonAdapter.fromJson(reader)
@@ -110,9 +110,14 @@ class DependencyLockReader {
                     reader.close()
                 }
             }
+            return result != null ? result : [:]
         } catch (ex) {
             if (logger.isDebugEnabled()) {
-                logger.debug('Unreadable json file: ' + lock.text)
+                try {
+                    logger.debug('Unreadable json file: ' + lock.text)
+                } catch (ignored) {
+                    logger.debug("Could not re-read ${lock.absolutePath} for debug logging")
+                }
             }
             logger.error("JSON unreadable: ${lock.absolutePath}")
             throw new GradleException("${lock.name} is unreadable or invalid json, terminating run", ex)

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockReader.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockReader.groovy
@@ -91,7 +91,12 @@ class DependencyLockReader {
         def override = project.findProperty('dependencyLock.override')
         if (override) {
             override.toString().tokenize(',').each {
-                def (group, artifact, version) = it.tokenize(':')
+                def parts = it.tokenize(':')
+                if (parts.size() < 3) {
+                    logger.warn("Invalid override '${it}': expected format is group:artifact:version — skipping")
+                    return
+                }
+                def (group, artifact, version) = parts
                 overrides["${group}:${artifact}".toString()] = version
                 logger.debug "Override added for: ${it}"
             }

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
@@ -315,7 +315,7 @@ class DependencyLockTaskConfigurer {
             globalGenerateTask.projectDirectory.set(project.layout.projectDirectory)
             globalGenerateTask.globalLockFileName.set(lockFilename ?: extension.globalLockFileProperty.get())
             globalGenerateTask.dependencyLockIgnored.set(project.provider { shouldIgnoreDependencyLock(project) })
-            globalGenerateTask.skippedDependencies.set(extension.skippedDependencies)
+            globalGenerateTask.skippedDependencies.set(extension.skippedDependenciesProperty)
             globalGenerateTask.overrides.set(overrides)
             globalGenerateTask.filter = extension.dependencyFilter
 

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
@@ -242,7 +242,7 @@ class DependencyLockTaskConfigurer {
             // Set output file
             it.dependenciesLock.set(project.layout.buildDirectory.file(lockFilename ?: extension.lockFile.get()))
             // Set configuration names
-            it.configurationNames.set(extension.configurationNames)
+            it.configurationNames.set(extension.configurationNamesProperty)
             it.skippedConfigurationNames.set(extension.skippedConfigurationNamesPrefixesProperty)
 
             // Always regenerate lock files - dependency changes in build.gradle aren't tracked as task inputs
@@ -278,7 +278,7 @@ class DependencyLockTaskConfigurer {
 
             // Build resolution map at config time so the task does not hold provider chains that capture project.
             // Intentionally resolve configurationNames and skippedConfigurationNamesPrefixes here (not lazy) for config-cache compatibility.
-            def configNames = extension.configurationNames.get()
+            def configNames = extension.configurationNamesProperty.get()
             def skippedNames = extension.skippedConfigurationNamesPrefixesProperty.get()
             def lockableConfs = GenerateLockTask.lockableConfigurations(project, project, configNames, skippedNames)
             def resolutionMap = lockableConfs.collectEntries { conf ->
@@ -337,8 +337,8 @@ class DependencyLockTaskConfigurer {
                     def subprojects = project.subprojects.collect { subproject ->
                         def ext = subproject.getExtensions().findByType(DependencyLockExtension)
                         if (ext != null) {
-                            Collection<Configuration> lockableConfigurations = lockableConfigurations(project, subproject, ext.configurationNames.get(), extension.skippedConfigurationNamesPrefixesProperty.get())
-                            Collection<Configuration> configurations = filterNonLockableConfigurationsAndProvideWarningsForGlobalLockSubproject(subproject, ext.configurationNames.get(), lockableConfigurations)
+                            Collection<Configuration> lockableConfigurations = lockableConfigurations(project, subproject, ext.configurationNamesProperty.get(), extension.skippedConfigurationNamesPrefixesProperty.get())
+                            Collection<Configuration> configurations = filterNonLockableConfigurationsAndProvideWarningsForGlobalLockSubproject(subproject, ext.configurationNamesProperty.get(), lockableConfigurations)
                             // Use unique name to avoid conflicts if evaluated multiple times
                             Configuration aggregate = subproject.configurations.create("aggregateConfiguration_${nextUniqueConfigSuffix.getAndIncrement()}_${subproject.path.replace(':', '_')}")
                             aggregate.setCanBeConsumed(true)
@@ -373,7 +373,7 @@ class DependencyLockTaskConfigurer {
                         configurations.add(conf)
                     }
 
-                    configurations + lockableConfigurations(project, project, extension.configurationNames.get(), extension.skippedConfigurationNamesPrefixesProperty.get())
+                    configurations + lockableConfigurations(project, project, extension.configurationNamesProperty.get(), extension.skippedConfigurationNamesPrefixesProperty.get())
                 }
             }
         }
@@ -386,14 +386,14 @@ class DependencyLockTaskConfigurer {
         def migrateToCoreLocksTask = project.tasks.register(MIGRATE_TO_CORE_LOCKS_TASK_NAME, MigrateToCoreLocksTask)
 
         migrateLockedDepsToCoreLocksTask.configure {
-            it.configurationNames.set(extension.configurationNames)
+            it.configurationNames.set(extension.configurationNamesProperty)
             it.inputLockFile.set(project.layout.projectDirectory.file(extension.lockFile))
             it.outputLock.set(project.layout.projectDirectory.file('gradle.lockfile'))
             it.notCompatibleWithConfigurationCache("Dependency locking plugin tasks require project access. Please consider using Gradle's dependency locking mechanism")
         }
 
         migrateToCoreLocksTask.configure {
-            it.configurationNames.set(extension.configurationNames)
+            it.configurationNames.set(extension.configurationNamesProperty)
             it.outputLock.set(project.layout.projectDirectory.file('gradle.lockfile'))
             it.dependsOn project.tasks.named(MIGRATE_LOCKED_DEPS_TO_CORE_LOCKS_TASK_NAME)
             it.notCompatibleWithConfigurationCache("Dependency locking plugin tasks require project access. Please consider using Gradle's dependency locking mechanism")
@@ -451,7 +451,7 @@ class DependencyLockTaskConfigurer {
 
             // Wire resolution results for path-aware diff (configuration cache compatible!)
             diffTask.resolutionResults.set(
-                extension.configurationNames.zip(extension.skippedConfigurationNamesPrefixesProperty) { configNames, skippedNames ->
+                extension.configurationNamesProperty.zip(extension.skippedConfigurationNamesPrefixesProperty) { configNames, skippedNames ->
                     def lockableConfs = GenerateLockTask.lockableConfigurations(project, project, configNames, skippedNames)
 
                     lockableConfs.collectEntries { conf ->

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
@@ -243,7 +243,7 @@ class DependencyLockTaskConfigurer {
             it.dependenciesLock.set(project.layout.buildDirectory.file(lockFilename ?: extension.lockFile.get()))
             // Set configuration names
             it.configurationNames.set(extension.configurationNames)
-            it.skippedConfigurationNames.set(extension.skippedConfigurationNamesPrefixes)
+            it.skippedConfigurationNames.set(extension.skippedConfigurationNamesPrefixesProperty)
 
             // Always regenerate lock files - dependency changes in build.gradle aren't tracked as task inputs
             it.outputs.upToDateWhen { false }
@@ -279,7 +279,7 @@ class DependencyLockTaskConfigurer {
             // Build resolution map at config time so the task does not hold provider chains that capture project.
             // Intentionally resolve configurationNames and skippedConfigurationNamesPrefixes here (not lazy) for config-cache compatibility.
             def configNames = extension.configurationNames.get()
-            def skippedNames = extension.skippedConfigurationNamesPrefixes.get()
+            def skippedNames = extension.skippedConfigurationNamesPrefixesProperty.get()
             def lockableConfs = GenerateLockTask.lockableConfigurations(project, project, configNames, skippedNames)
             def resolutionMap = lockableConfs.collectEntries { conf ->
                 [(conf.name): conf.incoming.resolutionResult.rootComponent]
@@ -337,7 +337,7 @@ class DependencyLockTaskConfigurer {
                     def subprojects = project.subprojects.collect { subproject ->
                         def ext = subproject.getExtensions().findByType(DependencyLockExtension)
                         if (ext != null) {
-                            Collection<Configuration> lockableConfigurations = lockableConfigurations(project, subproject, ext.configurationNames.get(), extension.skippedConfigurationNamesPrefixes.get())
+                            Collection<Configuration> lockableConfigurations = lockableConfigurations(project, subproject, ext.configurationNames.get(), extension.skippedConfigurationNamesPrefixesProperty.get())
                             Collection<Configuration> configurations = filterNonLockableConfigurationsAndProvideWarningsForGlobalLockSubproject(subproject, ext.configurationNames.get(), lockableConfigurations)
                             // Use unique name to avoid conflicts if evaluated multiple times
                             Configuration aggregate = subproject.configurations.create("aggregateConfiguration_${nextUniqueConfigSuffix.getAndIncrement()}_${subproject.path.replace(':', '_')}")
@@ -346,7 +346,7 @@ class DependencyLockTaskConfigurer {
                             configurations
                                     .findAll { configuration ->
                                         !configurationsToSkipForGlobalLockPrefixes.any { String prefix -> configuration.name.startsWith(prefix) }
-                                                && !extension.skippedConfigurationNamesPrefixes.get().any { String prefix -> configuration.name.startsWith(prefix) }
+                                                && !extension.skippedConfigurationNamesPrefixesProperty.get().any { String prefix -> configuration.name.startsWith(prefix) }
                                     }
                                     .each { configuration ->
                                         aggregate.extendsFrom(configuration)
@@ -373,7 +373,7 @@ class DependencyLockTaskConfigurer {
                         configurations.add(conf)
                     }
 
-                    configurations + lockableConfigurations(project, project, extension.configurationNames.get(), extension.skippedConfigurationNamesPrefixes.get())
+                    configurations + lockableConfigurations(project, project, extension.configurationNames.get(), extension.skippedConfigurationNamesPrefixesProperty.get())
                 }
             }
         }
@@ -451,7 +451,7 @@ class DependencyLockTaskConfigurer {
 
             // Wire resolution results for path-aware diff (configuration cache compatible!)
             diffTask.resolutionResults.set(
-                extension.configurationNames.zip(extension.skippedConfigurationNamesPrefixes) { configNames, skippedNames ->
+                extension.configurationNames.zip(extension.skippedConfigurationNamesPrefixesProperty) { configNames, skippedNames ->
                     def lockableConfs = GenerateLockTask.lockableConfigurations(project, project, configNames, skippedNames)
 
                     lockableConfs.collectEntries { conf ->

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
@@ -261,7 +261,7 @@ class DependencyLockTaskConfigurer {
             // task holds a plain value (no provider chain with non-serializable lambdas for config cache).
             Boolean includeTransitives = project.findProperty('dependencyLock.includeTransitives')?.toString()?.toBoolean()
             if (includeTransitives == null) {
-                includeTransitives = extension.includeTransitives.getOrElse(false)
+                includeTransitives = extension.includeTransitivesProperty.getOrElse(false)
             }
             generateTask.includeTransitives.set(includeTransitives)
 
@@ -332,7 +332,7 @@ class DependencyLockTaskConfigurer {
             // because it creates aggregate configurations at execution time. This needs a proper Property-based solution.
             // For now, keeping conventionMapping for this specific case to maintain functionality.
             globalGenerateTask.conventionMapping.with {
-                includeTransitives = { extension.includeTransitives.get() }
+                includeTransitives = { extension.includeTransitivesProperty.get() }
                 configurations = {
                     def subprojects = project.subprojects.collect { subproject ->
                         def ext = subproject.getExtensions().findByType(DependencyLockExtension)

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
@@ -144,7 +144,7 @@ class DependencyLockTaskConfigurer {
                     it.mustRunAfter(globalSaveTask)
                 }
                 // Resolve at config time so the task holds plain values (no provider chains for config cache)
-                String msg = project.findProperty('commitDependencyLock.message')?
+                String msg = project.findProperty('commitDependencyLock.message') as String
                 if (msg == null) {
                     msg = commitExtension.message.getOrElse('Committing dependency lock files')
                 }
@@ -157,7 +157,7 @@ class DependencyLockTaskConfigurer {
                     createTag = commitExtension.shouldCreateTag.getOrElse(false)
                 }
                 shouldCreateTag.set(createTag)
-                String tagVal = project.findProperty('commitDependencyLock.tag')?
+                String tagVal = project.findProperty('commitDependencyLock.tag') as String
                 if (tagVal == null) {
                     tagVal = commitExtension.tag.getOrElse("LockCommit-${new Date().format('yyyyMMddHHmmss')}")
                 }

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
@@ -112,19 +112,19 @@ class DependencyLockTaskConfigurer {
     }
 
     private File getProjectDirLockFile(String lockFilename, DependencyLockExtension extension) {
-        new File(project.projectDir, lockFilename ?: extension.lockFile.get())
+        new File(project.projectDir, lockFilename ?: extension.lockFileProperty.get())
     }
 
     private File getBuildDirLockFile(String lockFilename, DependencyLockExtension extension) {
-        new File(project.layout.buildDirectory.getAsFile().get(), lockFilename ?: extension.lockFile.get())
+        new File(project.layout.buildDirectory.getAsFile().get(), lockFilename ?: extension.lockFileProperty.get())
     }
 
     private File getProjectDirGlobalLockFile(String lockFilename, DependencyLockExtension extension) {
-        new File(project.projectDir, lockFilename ?: extension.globalLockFile.get())
+        new File(project.projectDir, lockFilename ?: extension.globalLockFileProperty.get())
     }
 
     private File getBuildDirGlobalLockFile(String lockFilename, DependencyLockExtension extension) {
-        new File(project.layout.buildDirectory.getAsFile().get(), lockFilename ?: extension.globalLockFile.get())
+        new File(project.layout.buildDirectory.getAsFile().get(), lockFilename ?: extension.globalLockFileProperty.get())
     }
 
     private void configureCommitTask(String clLockFileName, String globalLockFileName, TaskProvider<SaveLockTask> saveTask, DependencyLockExtension lockExtension,
@@ -169,8 +169,8 @@ class DependencyLockTaskConfigurer {
 
     private List<String> getPatternsToCommit(String clLockFileName, String globalLockFileName, DependencyLockExtension lockExtension) {
         List<String> patterns = []
-        patterns.add(clLockFileName ?: lockExtension.lockFile.get())
-        patterns.add(globalLockFileName ?: lockExtension.globalLockFile.get())
+        patterns.add(clLockFileName ?: lockExtension.lockFileProperty.get())
+        patterns.add(globalLockFileName ?: lockExtension.globalLockFileProperty.get())
         return patterns
     }
 
@@ -180,13 +180,13 @@ class DependencyLockTaskConfigurer {
 
         saveLockTask.configure { saveTask ->
             // Set input and output files using Property API
-            saveTask.generatedLock.set(project.layout.buildDirectory.file(lockFilename ?: extension.lockFile.get()))
-            saveTask.outputLock.set(project.layout.projectDirectory.file(lockFilename ?: extension.lockFile.get()))
+            saveTask.generatedLock.set(project.layout.buildDirectory.file(lockFilename ?: extension.lockFileProperty.get()))
+            saveTask.outputLock.set(project.layout.projectDirectory.file(lockFilename ?: extension.lockFileProperty.get()))
 
             // Configuration cache compatible: Capture global lock file path to check at execution time
             if (!isGlobalLockDisabled()) {
                 saveTask.globalLockFile.set(
-                    project.rootProject.layout.projectDirectory.file(extension.globalLockFile)
+                    project.rootProject.layout.projectDirectory.file(extension.globalLockFileProperty)
                 )
             }
         }
@@ -228,8 +228,8 @@ class DependencyLockTaskConfigurer {
                 }
             }
             // Set input and output files using Property API
-            globalSaveTask.generatedLock.set(project.layout.buildDirectory.file(lockFilename ?: extension.globalLockFile.get()))
-            globalSaveTask.outputLock.set(project.layout.projectDirectory.file(lockFilename ?: extension.globalLockFile.get()))
+            globalSaveTask.generatedLock.set(project.layout.buildDirectory.file(lockFilename ?: extension.globalLockFileProperty.get()))
+            globalSaveTask.outputLock.set(project.layout.projectDirectory.file(lockFilename ?: extension.globalLockFileProperty.get()))
         }
         configureCommonSaveTask(globalSaveLockTask, globalLockTask, globalUpdateLockTask)
 
@@ -240,7 +240,7 @@ class DependencyLockTaskConfigurer {
         setupLockProperties(lockTask, extension, overrides)
         lockTask.configure {
             // Set output file
-            it.dependenciesLock.set(project.layout.buildDirectory.file(lockFilename ?: extension.lockFile.get()))
+            it.dependenciesLock.set(project.layout.buildDirectory.file(lockFilename ?: extension.lockFileProperty.get()))
             // Set configuration names
             it.configurationNames.set(extension.configurationNamesProperty)
             it.skippedConfigurationNames.set(extension.skippedConfigurationNamesPrefixesProperty)
@@ -273,7 +273,7 @@ class DependencyLockTaskConfigurer {
 
             // Wire properties for configuration cache compatibility (resolve at config time, no project-capturing providers)
             generateTask.projectDirectory.set(project.layout.projectDirectory)
-            generateTask.globalLockFileName.set(extension.globalLockFile)
+            generateTask.globalLockFileName.set(extension.globalLockFileProperty)
             generateTask.dependencyLockIgnored.set(shouldIgnoreDependencyLock(project))
 
             // Build resolution map at config time so the task does not hold provider chains that capture project.
@@ -309,11 +309,11 @@ class DependencyLockTaskConfigurer {
             }
 
             // Set output file
-            globalGenerateTask.dependenciesLock.set(project.layout.buildDirectory.file(lockFilename ?: extension.globalLockFile.get()))
+            globalGenerateTask.dependenciesLock.set(project.layout.buildDirectory.file(lockFilename ?: extension.globalLockFileProperty.get()))
 
             // Wire minimal properties needed for basic checks in lock() method
             globalGenerateTask.projectDirectory.set(project.layout.projectDirectory)
-            globalGenerateTask.globalLockFileName.set(lockFilename ?: extension.globalLockFile.get())
+            globalGenerateTask.globalLockFileName.set(lockFilename ?: extension.globalLockFileProperty.get())
             globalGenerateTask.dependencyLockIgnored.set(project.provider { shouldIgnoreDependencyLock(project) })
             globalGenerateTask.skippedDependencies.set(extension.skippedDependencies)
             globalGenerateTask.overrides.set(overrides)
@@ -387,7 +387,7 @@ class DependencyLockTaskConfigurer {
 
         migrateLockedDepsToCoreLocksTask.configure {
             it.configurationNames.set(extension.configurationNamesProperty)
-            it.inputLockFile.set(project.layout.projectDirectory.file(extension.lockFile))
+            it.inputLockFile.set(project.layout.projectDirectory.file(extension.lockFileProperty))
             it.outputLock.set(project.layout.projectDirectory.file('gradle.lockfile'))
             it.notCompatibleWithConfigurationCache("Dependency locking plugin tasks require project access. Please consider using Gradle's dependency locking mechanism")
         }
@@ -438,8 +438,8 @@ class DependencyLockTaskConfigurer {
             diffTask.mustRunAfter(project.tasks.named(GENERATE_LOCK_TASK_NAME), project.tasks.named(UPDATE_LOCK_TASK_NAME))
 
             // Set file properties
-            def lockFileProvider = extension.lockFile.map { lockFileName ?: it }
-            def existing = new File(project.projectDir, lockFileName ?: extension.lockFile.get())
+            def lockFileProvider = extension.lockFileProperty.map { lockFileName ?: it }
+            def existing = new File(project.projectDir, lockFileName ?: extension.lockFileProperty.get())
             if (existing.exists()) {
                 diffTask.existingLockFile.set(project.layout.projectDirectory.file(lockFileProvider))
             }

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
@@ -255,7 +255,7 @@ class DependencyLockTaskConfigurer {
     private void setupLockProperties(TaskProvider<GenerateLockTask> task, DependencyLockExtension extension, Map overrideMap) {
         task.configure { generateTask ->
             // Set skipped dependencies
-            generateTask.skippedDependencies.set(extension.skippedDependencies)
+            generateTask.skippedDependencies.set(extension.skippedDependenciesProperty)
 
             // Set includeTransitives: gradle property overrides extension. Resolve at config time so the
             // task holds a plain value (no provider chain with non-serializable lambdas for config cache).

--- a/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/DependencyLockTaskConfigurer.groovy
@@ -15,6 +15,10 @@
  */
 package nebula.plugin.dependencylock
 
+import static nebula.plugin.dependencylock.tasks.GenerateLockTask.filterNonLockableConfigurationsAndProvideWarningsForGlobalLockSubproject
+import static nebula.plugin.dependencylock.tasks.GenerateLockTask.lockableConfigurations
+
+import java.util.concurrent.atomic.AtomicInteger
 import nebula.plugin.dependencylock.tasks.CommitLockTask
 import nebula.plugin.dependencylock.tasks.DiffLockTask
 import nebula.plugin.dependencylock.tasks.GenerateLockTask
@@ -33,12 +37,8 @@ import org.gradle.api.tasks.Delete
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.internal.deprecation.DeprecationLogger
 
-import java.util.concurrent.atomic.AtomicInteger
-
-import static nebula.plugin.dependencylock.tasks.GenerateLockTask.filterNonLockableConfigurationsAndProvideWarningsForGlobalLockSubproject
-import static nebula.plugin.dependencylock.tasks.GenerateLockTask.lockableConfigurations
-
 class DependencyLockTaskConfigurer {
+
     private static final Logger LOGGER = Logging.getLogger(DependencyLockTaskConfigurer)
 
     /** Counter for unique config names (globalLockConfig, aggregateConfiguration_) so names are deterministic within a build. */
@@ -51,8 +51,8 @@ class DependencyLockTaskConfigurer {
     public static final String UPDATE_GLOBAL_LOCK_TASK_NAME = 'updateGlobalLock'
     public static final String UPDATE_LOCK_TASK_NAME = 'updateLock'
     public static final String GENERATE_LOCK_TASK_NAME = 'generateLock'
-    public static final String MIGRATE_LOCKED_DEPS_TO_CORE_LOCKS_TASK_NAME = "migrateLockeDepsToCoreLocks"
-    public static final String MIGRATE_TO_CORE_LOCKS_TASK_NAME = "migrateToCoreLocks"
+    public static final String MIGRATE_LOCKED_DEPS_TO_CORE_LOCKS_TASK_NAME = 'migrateLockeDepsToCoreLocks'
+    public static final String MIGRATE_TO_CORE_LOCKS_TASK_NAME = 'migrateToCoreLocks'
     public static final String DIFF_LOCK_TASK_NAME = 'diffLock'
     public static final String COMMIT_LOCK_TASK_NAME = 'commitLock'
     public static final String SAVE_LOCK_TASK_NAME = 'saveLock'
@@ -144,7 +144,7 @@ class DependencyLockTaskConfigurer {
                     it.mustRunAfter(globalSaveTask)
                 }
                 // Resolve at config time so the task holds plain values (no provider chains for config cache)
-                String msg = project.findProperty('commitDependencyLock.message')?.toString()
+                String msg = project.findProperty('commitDependencyLock.message')?
                 if (msg == null) {
                     msg = commitExtension.message.getOrElse('Committing dependency lock files')
                 }
@@ -157,7 +157,7 @@ class DependencyLockTaskConfigurer {
                     createTag = commitExtension.shouldCreateTag.getOrElse(false)
                 }
                 shouldCreateTag.set(createTag)
-                String tagVal = project.findProperty('commitDependencyLock.tag')?.toString()
+                String tagVal = project.findProperty('commitDependencyLock.tag')?
                 if (tagVal == null) {
                     tagVal = commitExtension.tag.getOrElse("LockCommit-${new Date().format('yyyyMMddHHmmss')}")
                 }
@@ -165,9 +165,9 @@ class DependencyLockTaskConfigurer {
                 rootDirPath.set(project.rootProject.projectDir.absolutePath)
             }
         }
-    }
+                                     }
 
-    private List<String> getPatternsToCommit(String clLockFileName, String globalLockFileName, DependencyLockExtension lockExtension ) {
+    private List<String> getPatternsToCommit(String clLockFileName, String globalLockFileName, DependencyLockExtension lockExtension) {
         List<String> patterns = []
         patterns.add(clLockFileName ?: lockExtension.lockFile.get())
         patterns.add(globalLockFileName ?: lockExtension.globalLockFile.get())
@@ -182,7 +182,7 @@ class DependencyLockTaskConfigurer {
             // Set input and output files using Property API
             saveTask.generatedLock.set(project.layout.buildDirectory.file(lockFilename ?: extension.lockFile.get()))
             saveTask.outputLock.set(project.layout.projectDirectory.file(lockFilename ?: extension.lockFile.get()))
-            
+
             // Configuration cache compatible: Capture global lock file path to check at execution time
             if (!isGlobalLockDisabled()) {
                 saveTask.globalLockFile.set(
@@ -193,7 +193,7 @@ class DependencyLockTaskConfigurer {
         configureCommonSaveTask(saveLockTask, lockTask, updateTask)
 
         saveLockTask
-    }
+                                                         }
 
     private static void configureCommonSaveTask(TaskProvider<SaveLockTask> saveLockTask, TaskProvider<GenerateLockTask> lockTask,
                                                 TaskProvider<UpdateLockTask> updateTask) {
@@ -210,7 +210,7 @@ class DependencyLockTaskConfigurer {
                 }
             }
         }
-    }
+                                                }
 
     private TaskProvider<SaveLockTask> configureGlobalSaveTask(String lockFilename, TaskProvider<GenerateLockTask> globalLockTask,
                                                                TaskProvider<UpdateLockTask> globalUpdateLockTask, DependencyLockExtension extension) {
@@ -234,7 +234,7 @@ class DependencyLockTaskConfigurer {
         configureCommonSaveTask(globalSaveLockTask, globalLockTask, globalUpdateLockTask)
 
         globalSaveLockTask
-    }
+                                                               }
 
     private TaskProvider<GenerateLockTask> configureGenerateLockTask(TaskProvider<GenerateLockTask> lockTask, String lockFilename, DependencyLockExtension extension, Map overrides) {
         setupLockProperties(lockTask, extension, overrides)
@@ -244,7 +244,7 @@ class DependencyLockTaskConfigurer {
             // Set configuration names
             it.configurationNames.set(extension.configurationNames)
             it.skippedConfigurationNames.set(extension.skippedConfigurationNamesPrefixes)
-            
+
             // Always regenerate lock files - dependency changes in build.gradle aren't tracked as task inputs
             it.outputs.upToDateWhen { false }
         }
@@ -256,7 +256,7 @@ class DependencyLockTaskConfigurer {
         task.configure { generateTask ->
             // Set skipped dependencies
             generateTask.skippedDependencies.set(extension.skippedDependencies)
-            
+
             // Set includeTransitives: gradle property overrides extension. Resolve at config time so the
             // task holds a plain value (no provider chain with non-serializable lambdas for config cache).
             Boolean includeTransitives = project.findProperty('dependencyLock.includeTransitives')?.toString()?.toBoolean()
@@ -307,10 +307,10 @@ class DependencyLockTaskConfigurer {
                     project.subprojects.each { sub -> sub.repositories.each { repo -> project.repositories.add(repo) } }
                 }
             }
-            
+
             // Set output file
             globalGenerateTask.dependenciesLock.set(project.layout.buildDirectory.file(lockFilename ?: extension.globalLockFile.get()))
-            
+
             // Wire minimal properties needed for basic checks in lock() method
             globalGenerateTask.projectDirectory.set(project.layout.projectDirectory)
             globalGenerateTask.globalLockFileName.set(lockFilename ?: extension.globalLockFile.get())
@@ -318,7 +318,7 @@ class DependencyLockTaskConfigurer {
             globalGenerateTask.skippedDependencies.set(extension.skippedDependencies)
             globalGenerateTask.overrides.set(overrides)
             globalGenerateTask.filter = extension.dependencyFilter
-            
+
             // Capture peer coordinates to avoid accessing project at execution time
             globalGenerateTask.peerProjectCoordinates.set(project.provider {
                 project.rootProject.allprojects.collect { p ->
@@ -327,7 +327,7 @@ class DependencyLockTaskConfigurer {
                     "${group}:${name}".toString()
                 }
             })
-            
+
             // TODO: Refactor this to not use conventionMapping. The global lock's configuration logic is complex
             // because it creates aggregate configurations at execution time. This needs a proper Property-based solution.
             // For now, keeping conventionMapping for this specific case to maintain functionality.
@@ -357,7 +357,6 @@ class DependencyLockTaskConfigurer {
                         }
                     }.flatten()
 
-
                     // Create a regular configuration instead of a detached one for Gradle 9.x compatibility
                     // Use a unique name that doesn't conflict with Gradle's reserved names
                     def subprojectsArray = subprojects.toArray(new Dependency[subprojects.size()])
@@ -380,7 +379,7 @@ class DependencyLockTaskConfigurer {
         }
 
         globalLockTask
-    }
+                                                                   }
 
     private TaskProvider<MigrateToCoreLocksTask> configureMigrateToCoreLocksTask(DependencyLockExtension extension) {
         def migrateLockedDepsToCoreLocksTask = project.tasks.register(MIGRATE_LOCKED_DEPS_TO_CORE_LOCKS_TASK_NAME, MigrateLockedDepsToCoreLocksTask)
@@ -389,14 +388,13 @@ class DependencyLockTaskConfigurer {
         migrateLockedDepsToCoreLocksTask.configure {
             it.configurationNames.set(extension.configurationNames)
             it.inputLockFile.set(project.layout.projectDirectory.file(extension.lockFile))
-            it.outputLock.set(project.layout.projectDirectory.file("gradle.lockfile"))
+            it.outputLock.set(project.layout.projectDirectory.file('gradle.lockfile'))
             it.notCompatibleWithConfigurationCache("Dependency locking plugin tasks require project access. Please consider using Gradle's dependency locking mechanism")
-
         }
 
         migrateToCoreLocksTask.configure {
             it.configurationNames.set(extension.configurationNames)
-            it.outputLock.set(project.layout.projectDirectory.file("gradle.lockfile"))
+            it.outputLock.set(project.layout.projectDirectory.file('gradle.lockfile'))
             it.dependsOn project.tasks.named(MIGRATE_LOCKED_DEPS_TO_CORE_LOCKS_TASK_NAME)
             it.notCompatibleWithConfigurationCache("Dependency locking plugin tasks require project access. Please consider using Gradle's dependency locking mechanism")
         }
@@ -410,7 +408,6 @@ class DependencyLockTaskConfigurer {
         deleteLockTask.configure { it ->
             it.delete saveLock.map { it.outputLock }
         }
-
     }
 
     private void createDeleteGlobalLock(TaskProvider<SaveLockTask> saveGlobalLock) {
@@ -439,7 +436,7 @@ class DependencyLockTaskConfigurer {
 
         diffLockTask.configure { diffTask ->
             diffTask.mustRunAfter(project.tasks.named(GENERATE_LOCK_TASK_NAME), project.tasks.named(UPDATE_LOCK_TASK_NAME))
-            
+
             // Set file properties
             def lockFileProvider = extension.lockFile.map { lockFileName ?: it }
             def existing = new File(project.projectDir, lockFileName ?: extension.lockFile.get())
@@ -447,16 +444,16 @@ class DependencyLockTaskConfigurer {
                 diffTask.existingLockFile.set(project.layout.projectDirectory.file(lockFileProvider))
             }
             diffTask.updatedLockFile.set(project.layout.buildDirectory.file(lockFileProvider))
-            
+
             // Set output properties
-            diffTask.outputDir.set(project.layout.buildDirectory.dir("dependency-lock"))
+            diffTask.outputDir.set(project.layout.buildDirectory.dir('dependency-lock'))
             diffTask.diffFile.set(diffTask.outputDir.file("lockdiff.${diffTask.diffFileExtension()}"))
-            
+
             // Wire resolution results for path-aware diff (configuration cache compatible!)
             diffTask.resolutionResults.set(
                 extension.configurationNames.zip(extension.skippedConfigurationNamesPrefixes) { configNames, skippedNames ->
                     def lockableConfs = GenerateLockTask.lockableConfigurations(project, project, configNames, skippedNames)
-                    
+
                     lockableConfs.collectEntries { conf ->
                         [(conf.name): conf.incoming.resolutionResult.rootComponent]
                     }

--- a/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/utils/CoreLockingHelper.groovy
@@ -136,7 +136,7 @@ class CoreLockingHelper {
         def additionalConfigurationsToLockViaProperty = project.providers.gradleProperty(ADDITIONAL_CONFIGS_TO_LOCK)
                 .map { it.split(",") as Set<String> }
                 .getOrElse([] as Set)
-        def additionalConfigurationsToLockViaExtension = dependencyLockExtension.additionalConfigurationsToLock.get() as Set<String>
+        def additionalConfigurationsToLockViaExtension = dependencyLockExtension.additionalConfigurationsToLockProperty.get() as Set<String>
         def additionalConfigNames = additionalConfigurationsToLockViaProperty + additionalConfigurationsToLockViaExtension
         additionalConfigNames
     }

--- a/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
@@ -32,8 +32,22 @@ import org.gradle.api.provider.SetProperty
  */
 abstract class DependencyResolutionVerifierExtension {
 
-    /** Fail the build when verification finds issues. Default: true */
-    abstract Property<Boolean> getShouldFailTheBuild()
+    /**
+     * Fail the build when verification finds issues. Default: true
+     *
+     * The backing Property is exposed via {@link #getShouldFailTheBuildProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old {@code boolean}
+     * API so existing build scripts continue to work without modification.
+     */
+    abstract Property<Boolean> getShouldFailTheBuildProperty()
+
+    Boolean getShouldFailTheBuild() {
+        return shouldFailTheBuildProperty.get()
+    }
+
+    void setShouldFailTheBuild(Boolean value) {
+        shouldFailTheBuildProperty.set(value)
+    }
 
     /**
      * Configuration names to exclude from verification. Default: empty set
@@ -52,11 +66,39 @@ abstract class DependencyResolutionVerifierExtension {
         configurationsToExcludeProperty.set(values)
     }
 
-    /** Message to append when missing versions are detected. Default: empty */
-    abstract Property<String> getMissingVersionsMessageAddition()
+    /**
+     * Message to append when missing versions are detected. Default: empty
+     *
+     * The backing Property is exposed via {@link #getMissingVersionsMessageAdditionProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old {@code String}
+     * API so existing build scripts continue to work without modification.
+     */
+    abstract Property<String> getMissingVersionsMessageAdditionProperty()
 
-    /** Message to append when resolved version does not match locked. Default: empty */
-    abstract Property<String> getResolvedVersionDoesNotEqualLockedVersionMessageAddition()
+    String getMissingVersionsMessageAddition() {
+        return missingVersionsMessageAdditionProperty.get()
+    }
+
+    void setMissingVersionsMessageAddition(String value) {
+        missingVersionsMessageAdditionProperty.set(value)
+    }
+
+    /**
+     * Message to append when resolved version does not match locked. Default: empty
+     *
+     * The backing Property is exposed via {@link #getResolvedVersionDoesNotEqualLockedVersionMessageAdditionProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old {@code String}
+     * API so existing build scripts continue to work without modification.
+     */
+    abstract Property<String> getResolvedVersionDoesNotEqualLockedVersionMessageAdditionProperty()
+
+    String getResolvedVersionDoesNotEqualLockedVersionMessageAddition() {
+        return resolvedVersionDoesNotEqualLockedVersionMessageAdditionProperty.get()
+    }
+
+    void setResolvedVersionDoesNotEqualLockedVersionMessageAddition(String value) {
+        resolvedVersionDoesNotEqualLockedVersionMessageAdditionProperty.set(value)
+    }
 
     /**
      * Task names to exclude from verification. Default: empty set
@@ -75,16 +117,30 @@ abstract class DependencyResolutionVerifierExtension {
         tasksToExcludeProperty.set(values)
     }
 
-    /** When true (default): full lock validation. When false: only resolution errors, config cache compatible. */
-    abstract Property<Boolean> getEnableLockFileValidation()
+    /**
+     * When true (default): full lock validation. When false: only resolution errors, config cache compatible.
+     *
+     * The backing Property is exposed via {@link #getEnableLockFileValidationProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old {@code boolean}
+     * API so existing build scripts continue to work without modification.
+     */
+    abstract Property<Boolean> getEnableLockFileValidationProperty()
+
+    Boolean getEnableLockFileValidation() {
+        return enableLockFileValidationProperty.get()
+    }
+
+    void setEnableLockFileValidation(Boolean value) {
+        enableLockFileValidationProperty.set(value)
+    }
 
     DependencyResolutionVerifierExtension() {
-        shouldFailTheBuild.convention(true)
+        shouldFailTheBuildProperty.convention(true)
         configurationsToExcludeProperty.convention([] as Set)
-        missingVersionsMessageAddition.convention('')
-        resolvedVersionDoesNotEqualLockedVersionMessageAddition.convention('')
+        missingVersionsMessageAdditionProperty.convention('')
+        resolvedVersionDoesNotEqualLockedVersionMessageAdditionProperty.convention('')
         tasksToExcludeProperty.convention([] as Set)
-        enableLockFileValidation.convention(true)
+        enableLockFileValidationProperty.convention(true)
     }
 
 }

--- a/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
@@ -59,7 +59,7 @@ abstract class DependencyResolutionVerifierExtension {
     abstract SetProperty<String> getConfigurationsToExcludeProperty()
 
     Set<String> getConfigurationsToExclude() {
-        return configurationsToExcludeProperty.get()
+        return new LinkedHashSet<>(configurationsToExcludeProperty.get())
     }
 
     void setConfigurationsToExclude(Iterable<String> values) {
@@ -110,7 +110,7 @@ abstract class DependencyResolutionVerifierExtension {
     abstract SetProperty<String> getTasksToExcludeProperty()
 
     Set<String> getTasksToExclude() {
-        return tasksToExcludeProperty.get()
+        return new LinkedHashSet<>(tasksToExcludeProperty.get())
     }
 
     void setTasksToExclude(Iterable<String> values) {

--- a/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
@@ -31,6 +31,7 @@ import org.gradle.api.provider.SetProperty
  * {@code extension.foo = [...]} assignment syntax. Both sides must be kept.
  */
 abstract class DependencyResolutionVerifierExtension {
+
     /** Fail the build when verification finds issues. Default: true */
     abstract Property<Boolean> getShouldFailTheBuild()
 
@@ -85,4 +86,5 @@ abstract class DependencyResolutionVerifierExtension {
         tasksToExcludeProperty.convention([] as Set)
         enableLockFileValidation.convention(true)
     }
+
 }

--- a/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
@@ -23,8 +23,22 @@ abstract class DependencyResolutionVerifierExtension {
     /** Fail the build when verification finds issues. Default: true */
     abstract Property<Boolean> getShouldFailTheBuild()
 
-    /** Configuration names to exclude from verification. Default: empty set */
-    abstract SetProperty<String> getConfigurationsToExclude()
+    /**
+     * Configuration names to exclude from verification. Default: empty set
+     *
+     * The backing SetProperty is exposed via {@link #getConfigurationsToExcludeProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old Set&lt;String&gt;
+     * API so existing build scripts continue to work without modification.
+     */
+    abstract SetProperty<String> getConfigurationsToExcludeProperty()
+
+    Set<String> getConfigurationsToExclude() {
+        return configurationsToExcludeProperty.get()
+    }
+
+    void setConfigurationsToExclude(Iterable<String> values) {
+        configurationsToExcludeProperty.set(values)
+    }
 
     /** Message to append when missing versions are detected. Default: empty */
     abstract Property<String> getMissingVersionsMessageAddition()
@@ -32,18 +46,32 @@ abstract class DependencyResolutionVerifierExtension {
     /** Message to append when resolved version does not match locked. Default: empty */
     abstract Property<String> getResolvedVersionDoesNotEqualLockedVersionMessageAddition()
 
-    /** Task names to exclude from verification. Default: empty set */
-    abstract SetProperty<String> getTasksToExclude()
+    /**
+     * Task names to exclude from verification. Default: empty set
+     *
+     * The backing SetProperty is exposed via {@link #getTasksToExcludeProperty()} for
+     * config-cache-compatible task wiring. The getter/setter here preserve the old Set&lt;String&gt;
+     * API so existing build scripts continue to work without modification.
+     */
+    abstract SetProperty<String> getTasksToExcludeProperty()
+
+    Set<String> getTasksToExclude() {
+        return tasksToExcludeProperty.get()
+    }
+
+    void setTasksToExclude(Iterable<String> values) {
+        tasksToExcludeProperty.set(values)
+    }
 
     /** When true (default): full lock validation. When false: only resolution errors, config cache compatible. */
     abstract Property<Boolean> getEnableLockFileValidation()
 
     DependencyResolutionVerifierExtension() {
         shouldFailTheBuild.convention(true)
-        configurationsToExclude.convention([] as Set)
+        configurationsToExcludeProperty.convention([] as Set)
         missingVersionsMessageAddition.convention('')
         resolvedVersionDoesNotEqualLockedVersionMessageAddition.convention('')
-        tasksToExclude.convention([] as Set)
+        tasksToExcludeProperty.convention([] as Set)
         enableLockFileValidation.convention(true)
     }
 }

--- a/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
@@ -18,7 +18,18 @@ package nebula.plugin.dependencyverifier
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.SetProperty
 
-/** Extension for dependency resolution verification (Property API, config-cache friendly). */
+/**
+ * Extension for dependency resolution verification (Property API, config-cache friendly).
+ *
+ * <h3>SetProperty backward-compat bridge convention</h3>
+ *
+ * Every {@code SetProperty<String>} field follows a two-name convention — see
+ * {@link nebula.plugin.dependencylock.DependencyLockExtension} for the full explanation.
+ * In short: {@code getFooProperty()} is the Gradle-managed backing store for internal
+ * config-cache-safe task wiring; {@code getFoo()} / {@code setFoo(Iterable<String>)} are the
+ * public backward-compatible API that downstream Groovy build scripts call via
+ * {@code extension.foo = [...]} assignment syntax. Both sides must be kept.
+ */
 abstract class DependencyResolutionVerifierExtension {
     /** Fail the build when verification finds issues. Default: true */
     abstract Property<Boolean> getShouldFailTheBuild()

--- a/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
+++ b/src/main/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtension.groovy
@@ -136,10 +136,10 @@ abstract class DependencyResolutionVerifierExtension {
 
     DependencyResolutionVerifierExtension() {
         shouldFailTheBuildProperty.convention(true)
-        configurationsToExcludeProperty.convention([] as Set)
+        configurationsToExcludeProperty.convention([] as Set<String>)
         missingVersionsMessageAdditionProperty.convention('')
         resolvedVersionDoesNotEqualLockedVersionMessageAdditionProperty.convention('')
-        tasksToExcludeProperty.convention([] as Set)
+        tasksToExcludeProperty.convention([] as Set<String>)
         enableLockFileValidationProperty.convention(true)
     }
 

--- a/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
+++ b/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
@@ -135,7 +135,7 @@ class DependencyLockPlugin @Inject constructor(
         if (DependencyLockingFeatureFlags.isCoreLockingEnabled()) {
             LOGGER.info("${project.name}: coreLockingSupport feature enabled")
             val coreLockingHelper = CoreLockingHelper(project)
-            coreLockingHelper.lockSelectedConfigurations(extension.configurationNames.get())
+            coreLockingHelper.lockSelectedConfigurations(extension.configurationNamesProperty.get())
 
             coreLockingHelper.disableCachingWhenUpdatingDependencies()
             coreLockingHelper.notifyWhenUsingOfflineMode()
@@ -239,7 +239,7 @@ class DependencyLockPlugin @Inject constructor(
             // Use provider to allow gradle property to override extension property
             val updates = project.providers.gradleProperty(UPDATE_DEPENDENCIES)
                 .map { parseUpdates(it) }
-                .orElse(extension.updateDependencies)
+                .orElse(extension.updateDependenciesProperty)
                 .get()
             
             // Resolve validation flags using Provider API

--- a/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
+++ b/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
@@ -245,15 +245,15 @@ class DependencyLockPlugin @Inject constructor(
             // Resolve validation flags using Provider API
             val validateCoordinates = project.providers.gradleProperty(VALIDATE_DEPENDENCY_COORDINATES)
                 .map { it.toBoolean() }
-                .orElse(extension.updateDependenciesFailOnInvalidCoordinates)
+                .orElse(extension.updateDependenciesFailOnInvalidCoordinatesProperty)
                 .get()
             val validateSimultaneousTasks = project.providers.gradleProperty(VALIDATE_SIMULTANEOUS_TASKS)
                 .map { it.toBoolean() }
-                .orElse(extension.updateDependenciesFailOnSimultaneousTaskUsage)
+                .orElse(extension.updateDependenciesFailOnSimultaneousTaskUsageProperty)
                 .get()
             val validateSpecifiedDependenciesToUpdate = project.providers.gradleProperty(VALIDATE_SPECIFIED_DEPENDENCIES_TO_UPDATE)
                 .map { it.toBoolean() }
-                .orElse(extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate)
+                .orElse(extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdateProperty)
                 .get()
             
             UpdateDependenciesValidator.validate(

--- a/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
+++ b/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
@@ -213,7 +213,7 @@ class DependencyLockPlugin @Inject constructor(
     }
 
     private fun maybeApplyLock(conf: Configuration, extension: DependencyLockExtension, overrides: Map<*, *>, globalLockFileName: String?, lockFilename: String?) {
-        val shouldIgnoreLock = (extension.skippedConfigurationNamesPrefixes.get() + DependencyLockTaskConfigurer.configurationsToSkipForGlobalLockPrefixes).any {
+        val shouldIgnoreLock = (extension.skippedConfigurationNamesPrefixesProperty.get() + DependencyLockTaskConfigurer.configurationsToSkipForGlobalLockPrefixes).any {
             prefix -> conf.name.startsWith(prefix) && !conf.name.contains("resolutionRules")
         }
         if(shouldIgnoreLock) {

--- a/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
+++ b/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
@@ -107,16 +107,19 @@ class DependencyLockPlugin @Inject constructor(
             /* MigrateToCoreLocks can be involved with migrating dependencies that were previously unlocked.
                Verifying resolution based on the base lockfiles causes a `LockOutOfDateException` from the initial DependencyLockingArtifactVisitor state
             */
-            // Defer verification setup until after project evaluation
-            // This ensures other plugins (like java) have created their configurations first
+            val verifier = DependencyResolutionVerifier(
+                verificationService,
+                dependencyResolutionVerifierExtension,
+                flowScope,
+                flowProviders
+            )
+            // Register the task stub eagerly so downstream plugins that walk the task container
+            // (even inside afterEvaluate) don't hit an "immutable container" error.
+            val verificationTask = verifier.registerVerificationTask(project)
+            // Defer wiring of task parameters until after evaluation so configurations from other
+            // plugins (like 'java') are present when we build the resolution map.
             project.afterEvaluate {
-                // Pass BuildService provider, extension, and Flow API services to verifier
-                DependencyResolutionVerifier(
-                    verificationService, 
-                    dependencyResolutionVerifierExtension,
-                    flowScope,
-                    flowProviders
-                ).verifySuccessfulResolution(project)
+                verifier.verifySuccessfulResolution(project, verificationTask)
             }
         }
 

--- a/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
+++ b/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
@@ -140,7 +140,7 @@ class DependencyLockPlugin @Inject constructor(
             coreLockingHelper.disableCachingWhenUpdatingDependencies()
             coreLockingHelper.notifyWhenUsingOfflineMode()
 
-            val lockFile = File(project.projectDir, extension.lockFile.get())
+            val lockFile = File(project.projectDir, extension.lockFileProperty.get())
 
             if (lockFile.exists()) {
                 if (startParameter.isWriteDependencyLocks) {
@@ -160,7 +160,7 @@ class DependencyLockPlugin @Inject constructor(
             val taskNames = startParameter.taskNames
             val hasUpdateTask = hasUpdateTask(taskNames)
             val hasGenerationTask = hasGenerationTask(taskNames)
-            val globalLockFile = File(project.projectDir, extension.globalLockFile.get())
+            val globalLockFile = File(project.projectDir, extension.globalLockFileProperty.get())
 
             if (globalLockFile.exists() && !hasGenerationTask && !hasUpdateTask) {
                 // do not fail for generation or update tasks here. It's more readable when the task itself fails.
@@ -222,11 +222,11 @@ class DependencyLockPlugin @Inject constructor(
         if(shouldIgnoreLock) {
             return
         }
-        val globalLock = File(project.rootProject.projectDir, globalLockFileName ?: extension.globalLockFile.get())
+        val globalLock = File(project.rootProject.projectDir, globalLockFileName ?: extension.globalLockFileProperty.get())
         val dependenciesLock = if (globalLock.exists()) {
             globalLock
         } else {
-            File(project.projectDir, lockFilename ?: extension.lockFile.get())
+            File(project.projectDir, lockFilename ?: extension.lockFileProperty.get())
         }
 
         lockUsed = dependenciesLock.name

--- a/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
+++ b/src/main/kotlin/nebula/plugin/dependencylock/DependencyLockPlugin.kt
@@ -172,7 +172,7 @@ class DependencyLockPlugin @Inject constructor(
             // Use provider chain to allow gradle property to override extension property
             val lockAfterEvaluating = project.providers.gradleProperty(LOCK_AFTER_EVALUATING)
                 .map { it.toBoolean() }
-                .orElse(extension.lockAfterEvaluating)
+                .orElse(extension.lockAfterEvaluatingProperty)
                 .get()
             if (lockAfterEvaluating) {
                 LOGGER.info("Delaying dependency lock apply until beforeResolve ($LOCK_AFTER_EVALUATING set to true)")

--- a/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyResolutionVerifier.kt
+++ b/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyResolutionVerifier.kt
@@ -126,7 +126,9 @@ class DependencyResolutionVerifier(
             val effectiveLockValidation = extensionFromRoot.enableLockFileValidationProperty.get() && !ignoreLocks
             task.parameters.enableLockFileValidation.set(effectiveLockValidation)
             task.parameters.taskNames.set(project.gradle.startParameter.taskNames.toList())
-            task.parameters.coreAlignmentEnabled.set(System.getProperty("nebula.features.coreAlignmentSupport", "false").toBoolean())
+            task.parameters.coreAlignmentEnabled.set(
+                project.providers.systemProperty("nebula.features.coreAlignmentSupport").map { it.toBoolean() }.orElse(false)
+            )
             task.parameters.coreLockingEnabled.set(DependencyLockingFeatureFlags.isCoreLockingEnabled())
             task.parameters.reportingOnlyBuild.set(
                 ReportingTasks.isReportingTasksOnly(project.gradle.startParameter.taskNames.toList())

--- a/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyResolutionVerifier.kt
+++ b/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyResolutionVerifier.kt
@@ -113,9 +113,9 @@ class DependencyResolutionVerifier(
             task.parameters.projectKey.set(projectKey)
             task.parameters.projectName.set(projectName)
             task.parameters.shouldFailTheBuild.set(shouldFailTheBuild)
-            task.parameters.missingVersionsMessageAddition.set(extensionFromRoot.missingVersionsMessageAddition)
+            task.parameters.missingVersionsMessageAddition.set(extensionFromRoot.missingVersionsMessageAdditionProperty)
             task.parameters.resolvedVersionDoesNotEqualLockedVersionMessageAddition.set(
-                extensionFromRoot.resolvedVersionDoesNotEqualLockedVersionMessageAddition
+                extensionFromRoot.resolvedVersionDoesNotEqualLockedVersionMessageAdditionProperty
             )
             task.parameters.configurationsToExclude.set(configurationsToExclude)
             val ignoreLocks = try {
@@ -123,7 +123,7 @@ class DependencyResolutionVerifier(
             } catch (_: Exception) {
                 false
             }
-            val effectiveLockValidation = extensionFromRoot.enableLockFileValidation.get() && !ignoreLocks
+            val effectiveLockValidation = extensionFromRoot.enableLockFileValidationProperty.get() && !ignoreLocks
             task.parameters.enableLockFileValidation.set(effectiveLockValidation)
             task.parameters.taskNames.set(project.gradle.startParameter.taskNames.toList())
             task.parameters.coreAlignmentEnabled.set(System.getProperty("nebula.features.coreAlignmentSupport", "false").toBoolean())
@@ -167,7 +167,7 @@ class DependencyResolutionVerifier(
         }
 
     private fun getShouldFailTheBuild(project: Project): Boolean =
-        propertyOrExtension(project, UNRESOLVED_DEPENDENCIES_FAIL_THE_BUILD, extensionFromRoot.shouldFailTheBuild.get()) { it.toBoolean() }
+        propertyOrExtension(project, UNRESOLVED_DEPENDENCIES_FAIL_THE_BUILD, extensionFromRoot.shouldFailTheBuildProperty.get()) { it.toBoolean() }
 
     private fun uniqueProjectKey(project: Project): String {
         return "${project.name}-${if (project == project.rootProject) "rootproject" else "subproject"}"
@@ -285,14 +285,14 @@ class DependencyResolutionVerifier(
     private fun registerFlowActionStrategy(project: Project, projectKey: String) {
         val projectName = project.name
         val shouldFailTheBuild = getShouldFailTheBuild(project)
-        val lockMismatchMessage = extensionFromRoot.resolvedVersionDoesNotEqualLockedVersionMessageAddition.get()
+        val lockMismatchMessage = extensionFromRoot.resolvedVersionDoesNotEqualLockedVersionMessageAdditionProperty.get()
 
         flowScope.always(DependencyResolutionFlowAction::class.java) { spec ->
             spec.parameters.projectName.set(projectName)
             spec.parameters.projectKey.set(projectKey)
             spec.parameters.shouldFailTheBuild.set(shouldFailTheBuild)
             spec.parameters.lockMismatchMessage.set(lockMismatchMessage)
-            spec.parameters.missingVersionsMessageAddition.set(extensionFromRoot.missingVersionsMessageAddition.get())
+            spec.parameters.missingVersionsMessageAddition.set(extensionFromRoot.missingVersionsMessageAdditionProperty.get())
             spec.parameters.requestedTaskNames.set(project.gradle.startParameter.taskNames.toList())
             spec.parameters.buildResult.set(flowProviders.buildWorkResult)
             spec.parameters.verificationService.set(verificationService)

--- a/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyResolutionVerifier.kt
+++ b/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyResolutionVerifier.kt
@@ -31,6 +31,7 @@ import org.gradle.api.flow.FlowScope
 import org.gradle.api.logging.Logging
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.TaskCollection
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.diagnostics.DependencyInsightReportTask
 import org.gradle.api.tasks.diagnostics.DependencyReportTask
@@ -49,7 +50,10 @@ class DependencyResolutionVerifier(
 
     private val logger = Logging.getLogger(DependencyResolutionVerifier::class.java)
 
-    fun verifySuccessfulResolution(project: Project) {
+    fun registerVerificationTask(project: Project): TaskProvider<DependencyVerificationTask> =
+        project.tasks.register("verifyDependencyResolution", DependencyVerificationTask::class.java)
+
+    fun verifySuccessfulResolution(project: Project, verificationTask: TaskProvider<DependencyVerificationTask>) {
         val projectKey = uniqueProjectKey(project)
         val projectName = project.name
         verificationService.get().initializeProject(projectKey)
@@ -104,10 +108,7 @@ class DependencyResolutionVerifier(
             return Pair(effectiveResolutionResultsMap, effectiveConfigNames)
         }
 
-        val verificationTask = project.tasks.register(
-            "verifyDependencyResolution",
-            DependencyVerificationTask::class.java
-        ) { task ->
+        verificationTask.configure { task ->
             task.usesService(verificationService)
             task.parameters.projectKey.set(projectKey)
             task.parameters.projectName.set(projectName)

--- a/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyResolutionVerifier.kt
+++ b/src/main/kotlin/nebula/plugin/dependencyverifier/DependencyResolutionVerifier.kt
@@ -59,7 +59,7 @@ class DependencyResolutionVerifier(
         verificationService.get().initializeProject(projectKey)
         val configurationsToExclude = getConfigurationsToExclude(project)
         val shouldFailTheBuild = getShouldFailTheBuild(project)
-        val tasksToExclude = extensionFromRoot.tasksToExclude.get()
+        val tasksToExclude = extensionFromRoot.tasksToExcludeProperty.get()
         val requestedTasks = project.gradle.startParameter.taskNames
         val allTasksExcluded = requestedTasks.isNotEmpty() && requestedTasks.all { taskName ->
             val simpleTaskName = taskName.substringAfterLast(':')
@@ -162,7 +162,7 @@ class DependencyResolutionVerifier(
         project.findProperty(propName)?.let { parse(it.toString()) } ?: default
 
     private fun getConfigurationsToExclude(project: Project): Set<String> =
-        propertyOrExtension(project, CONFIGURATIONS_TO_EXCLUDE, extensionFromRoot.configurationsToExclude.get()) { str ->
+        propertyOrExtension(project, CONFIGURATIONS_TO_EXCLUDE, extensionFromRoot.configurationsToExcludeProperty.get()) { str ->
             str.split(",").map { it.trim() }.toSet()
         }
 

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
@@ -796,5 +796,45 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
         result.output.contains('remoteRetries: 5')
     }
 
+    def 'configurationNames bridge getter returns mutable Set (defensive copy)'() {
+        given:
+        buildFile << """
+            plugins { id 'com.netflix.nebula.dependency-lock' }
+            task checkMutable {
+                def ext = dependencyLock
+                doLast {
+                    def names = ext.configurationNames
+                    names.add('runtimeClasspath')
+                    println "added: " + names.contains('runtimeClasspath')
+                }
+            }
+        """
+        when:
+        def result = runTasks('checkMutable')
+        then:
+        result.output.contains('added: true')
+        !result.output.contains('UnsupportedOperationException')
+    }
+
+    def 'additionalConfigurationsToLock bridge getter returns mutable Set (defensive copy)'() {
+        given:
+        buildFile << """
+            plugins { id 'com.netflix.nebula.dependency-lock' }
+            task checkMutable {
+                def ext = dependencyLock
+                doLast {
+                    def configs = ext.additionalConfigurationsToLock
+                    configs.add('myConfig')
+                    println "added: " + configs.contains('myConfig')
+                }
+            }
+        """
+        when:
+        def result = runTasks('checkMutable')
+        then:
+        result.output.contains('added: true')
+        !result.output.contains('UnsupportedOperationException')
+    }
+
 }
 

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
@@ -796,6 +796,21 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
         result.output.contains('remoteRetries: 5')
     }
 
+    def 'setting dependencyFilter emits deprecation warning about configuration cache incompatibility'() {
+        given:
+        buildFile << """
+            plugins { id 'com.netflix.nebula.dependency-lock' }
+            dependencyLock {
+                dependencyFilter = { group, name, version -> !name.startsWith('internal') }
+            }
+            task doNothing
+        """
+        when:
+        def result = runTasks('doNothing')
+        then:
+        result.output.contains('dependencyFilter') && result.output.contains('deprecated')
+    }
+
     def 'configurationNames bridge getter returns mutable Set (defensive copy)'() {
         given:
         buildFile << """

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
@@ -207,6 +207,86 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
         result.output.contains('com.example:added')
     }
 
+    def 'skippedConfigurationNamesPrefixes supports Groovy = assignment (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            dependencyLock {
+                skippedConfigurationNamesPrefixes = ['test', 'compile'] as Set
+            }
+
+            task checkSkipped {
+                def ext = dependencyLock
+                doLast {
+                    println "skipped: " + ext.skippedConfigurationNamesPrefixes
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkSkipped')
+
+        then:
+        result.output.contains('test')
+        result.output.contains('compile')
+    }
+
+    def 'skippedConfigurationNamesPrefixes getter returns Set not SetProperty'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            task checkType {
+                def ext = dependencyLock
+                doLast {
+                    def value = ext.skippedConfigurationNamesPrefixes
+                    println "isSet: " + (value instanceof Set)
+                    println "isSetProperty: " + value.getClass().name.contains('SetProperty')
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkType')
+
+        then:
+        result.output.contains('isSet: true')
+        result.output.contains('isSetProperty: false')
+    }
+
+    def 'skippedConfigurationNamesPrefixes supports += operator (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            dependencyLock {
+                skippedConfigurationNamesPrefixes = ['test'] as Set
+            }
+            dependencyLock.skippedConfigurationNamesPrefixes += 'runtime'
+
+            task checkSkipped {
+                def ext = dependencyLock
+                doLast {
+                    println "skipped: " + ext.skippedConfigurationNamesPrefixes
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkSkipped')
+
+        then:
+        result.output.contains('test')
+        result.output.contains('runtime')
+    }
+
     def 'commit extension properties use default conventions'() {
         given:
         buildFile << """

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
@@ -17,8 +17,8 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
             task checkDefaults {
                 def ext = dependencyLock  // Capture during configuration
                 doLast {
-                    println "lockFile: " + ext.lockFile.get()
-                    println "globalLockFile: " + ext.globalLockFile.get()
+                    println "lockFile: " + ext.lockFile
+                    println "globalLockFile: " + ext.globalLockFile
                     println "includeTransitives: " + ext.includeTransitives.get()
                     println "lockAfterEvaluating: " + ext.lockAfterEvaluating.get()
                 }
@@ -43,7 +43,7 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
             }
 
             dependencyLock {
-                lockFile.set('custom.lock')
+                lockFileProperty.set('custom.lock')
                 includeTransitives.set(true)
                 lockAfterEvaluating.set(false)
             }
@@ -51,7 +51,7 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
             task checkConfig {
                 def ext = dependencyLock  // Capture during configuration
                 doLast {
-                    println "lockFile: " + ext.lockFile.get()
+                    println "lockFile: " + ext.lockFile
                     println "includeTransitives: " + ext.includeTransitives.get()
                     println "lockAfterEvaluating: " + ext.lockAfterEvaluating.get()
                 }
@@ -82,7 +82,7 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
             task checkConfig {
                 def ext = dependencyLock  // Capture during configuration
                 doLast {
-                    println "lockFile: " + ext.lockFile.get()
+                    println "lockFile: " + ext.lockFile
                     println "includeTransitives: " + ext.includeTransitives.get()
                 }
             }
@@ -440,6 +440,104 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
         then:
         result.output.contains('isSet: true')
         result.output.contains('isSetProperty: false')
+    }
+
+    def 'lockFile getter returns String not Property (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            task checkType {
+                def ext = dependencyLock
+                doLast {
+                    def value = ext.lockFile
+                    println "isString: " + (value instanceof String)
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkType')
+
+        then:
+        result.output.contains('isString: true')
+    }
+
+    def 'lockFile supports Groovy = assignment (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            dependencyLock {
+                lockFile = 'custom.lock'
+            }
+
+            task checkConfig {
+                def ext = dependencyLock
+                doLast {
+                    println "lockFile: " + ext.lockFile
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkConfig')
+
+        then:
+        result.output.contains('lockFile: custom.lock')
+    }
+
+    def 'globalLockFile getter returns String not Property (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            task checkType {
+                def ext = dependencyLock
+                doLast {
+                    def value = ext.globalLockFile
+                    println "isString: " + (value instanceof String)
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkType')
+
+        then:
+        result.output.contains('isString: true')
+    }
+
+    def 'globalLockFile supports Groovy = assignment (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            dependencyLock {
+                globalLockFile = 'custom-global.lock'
+            }
+
+            task checkConfig {
+                def ext = dependencyLock
+                doLast {
+                    println "globalLockFile: " + ext.globalLockFile
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkConfig')
+
+        then:
+        result.output.contains('globalLockFile: custom-global.lock')
     }
 
     def 'commit extension properties use default conventions'() {

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
@@ -824,7 +824,7 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
         when:
         def result = runTasks('doNothing')
         then:
-        result.output.contains('dependencyFilter') && result.output.contains('deprecated')
+        result.output.contains('dependencyFilter is deprecated: Closures are not configuration-cache compatible')
     }
 
     def 'configurationNames bridge getter returns mutable Set (defensive copy)'() {

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
@@ -15,12 +15,20 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
             }
 
             task checkDefaults {
-                def ext = dependencyLock  // Capture during configuration
+                def ext = dependencyLock
                 doLast {
                     println "lockFile: " + ext.lockFile
                     println "globalLockFile: " + ext.globalLockFile
+                    println "configurationNames: " + ext.configurationNames
+                    println "skippedConfigurationNamesPrefixes: " + ext.skippedConfigurationNamesPrefixes
+                    println "updateDependencies: " + ext.updateDependencies
+                    println "skippedDependencies: " + ext.skippedDependencies
                     println "includeTransitives: " + ext.includeTransitives
                     println "lockAfterEvaluating: " + ext.lockAfterEvaluating
+                    println "additionalConfigurationsToLock: " + ext.additionalConfigurationsToLock
+                    println "failOnInvalidCoordinates: " + ext.updateDependenciesFailOnInvalidCoordinates
+                    println "failOnSimultaneous: " + ext.updateDependenciesFailOnSimultaneousTaskUsage
+                    println "failOnNonSpecified: " + ext.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate
                 }
             }
         """
@@ -31,8 +39,16 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
         then:
         result.output.contains('lockFile: dependencies.lock')
         result.output.contains('globalLockFile: global.lock')
+        result.output.contains('configurationNames: []')
+        result.output.contains('skippedConfigurationNamesPrefixes: []')
+        result.output.contains('updateDependencies: []')
+        result.output.contains('skippedDependencies: []')
         result.output.contains('includeTransitives: false')
         result.output.contains('lockAfterEvaluating: true')
+        result.output.contains('additionalConfigurationsToLock: []')
+        result.output.contains('failOnInvalidCoordinates: true')
+        result.output.contains('failOnSimultaneous: true')
+        result.output.contains('failOnNonSpecified: true')
     }
 
     def 'extension properties can be configured via set()'() {

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
@@ -106,14 +106,14 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
             dependencyLock {
                 configurationNames.add('runtimeClasspath')
                 configurationNames.add('compileClasspath')
-                skippedDependencies.add('com.example:skip-me')
+                skippedDependenciesProperty.add('com.example:skip-me')
             }
 
             task checkConfig {
                 def ext = dependencyLock  // Capture during configuration
                 doLast {
                     println "configs: " + ext.configurationNames.get()
-                    println "skipped: " + ext.skippedDependencies.get()
+                    println "skipped: " + ext.skippedDependencies
                 }
             }
         """
@@ -125,6 +125,86 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
         result.output.contains('runtimeClasspath')
         result.output.contains('compileClasspath')
         result.output.contains('skip-me')
+    }
+
+    def 'skippedDependencies supports Groovy = assignment (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            dependencyLock {
+                skippedDependencies = ['com.example:foo', 'com.example:bar'] as Set
+            }
+
+            task checkSkipped {
+                def ext = dependencyLock
+                doLast {
+                    println "skipped: " + ext.skippedDependencies
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkSkipped')
+
+        then:
+        result.output.contains('com.example:foo')
+        result.output.contains('com.example:bar')
+    }
+
+    def 'skippedDependencies getter returns Set not SetProperty'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            task checkType {
+                def ext = dependencyLock
+                doLast {
+                    def value = ext.skippedDependencies
+                    println "isSet: " + (value instanceof Set)
+                    println "isSetProperty: " + value.getClass().name.contains('SetProperty')
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkType')
+
+        then:
+        result.output.contains('isSet: true')
+        result.output.contains('isSetProperty: false')
+    }
+
+    def 'skippedDependencies supports += operator (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            dependencyLock {
+                skippedDependencies = ['com.example:existing'] as Set
+            }
+            dependencyLock.skippedDependencies += 'com.example:added'
+
+            task checkSkipped {
+                def ext = dependencyLock
+                doLast {
+                    println "skipped: " + ext.skippedDependencies
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkSkipped')
+
+        then:
+        result.output.contains('com.example:existing')
+        result.output.contains('com.example:added')
     }
 
     def 'commit extension properties use default conventions'() {

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
@@ -638,6 +638,101 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
         result.output.contains('lockAfterEvaluating: false')
     }
 
+    def 'updateDependenciesFailOnInvalidCoordinates getter returns Boolean not Property (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            task checkType {
+                def ext = dependencyLock
+                doLast {
+                    def value = ext.updateDependenciesFailOnInvalidCoordinates
+                    println "isBoolean: " + (value instanceof Boolean)
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkType')
+
+        then:
+        result.output.contains('isBoolean: true')
+    }
+
+    def 'updateDependenciesFailOnInvalidCoordinates false assignment is respected (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            dependencyLock {
+                updateDependenciesFailOnInvalidCoordinates = false
+            }
+
+            task checkConfig {
+                def ext = dependencyLock
+                doLast {
+                    println "value: " + ext.updateDependenciesFailOnInvalidCoordinates
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkConfig')
+
+        then:
+        result.output.contains('value: false')
+    }
+
+    def 'updateDependenciesFailOnSimultaneousTaskUsage getter returns Boolean not Property (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            task checkType {
+                def ext = dependencyLock
+                doLast {
+                    def value = ext.updateDependenciesFailOnSimultaneousTaskUsage
+                    println "isBoolean: " + (value instanceof Boolean)
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkType')
+
+        then:
+        result.output.contains('isBoolean: true')
+    }
+
+    def 'updateDependenciesFailOnNonSpecifiedDependenciesToUpdate getter returns Boolean not Property (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            task checkType {
+                def ext = dependencyLock
+                doLast {
+                    def value = ext.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate
+                    println "isBoolean: " + (value instanceof Boolean)
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkType')
+
+        then:
+        result.output.contains('isBoolean: true')
+    }
+
     def 'commit extension properties use default conventions'() {
         given:
         buildFile << """

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
@@ -6,14 +6,14 @@ import nebula.plugin.BaseIntegrationTestKitSpec
  * Tests to validate that DependencyLockExtension uses Property API correctly.
  */
 class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
-    
+
     def 'extension properties use default conventions'() {
         given:
         buildFile << """
             plugins {
                 id 'com.netflix.nebula.dependency-lock'
             }
-            
+
             task checkDefaults {
                 def ext = dependencyLock  // Capture during configuration
                 doLast {
@@ -24,30 +24,30 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
                 }
             }
         """
-        
+
         when:
         def result = runTasks('checkDefaults')
-        
+
         then:
         result.output.contains('lockFile: dependencies.lock')
         result.output.contains('globalLockFile: global.lock')
         result.output.contains('includeTransitives: false')
         result.output.contains('lockAfterEvaluating: true')
     }
-    
+
     def 'extension properties can be configured via set()'() {
         given:
         buildFile << """
             plugins {
                 id 'com.netflix.nebula.dependency-lock'
             }
-            
+
             dependencyLock {
                 lockFile.set('custom.lock')
                 includeTransitives.set(true)
                 lockAfterEvaluating.set(false)
             }
-            
+
             task checkConfig {
                 def ext = dependencyLock  // Capture during configuration
                 doLast {
@@ -57,28 +57,28 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
                 }
             }
         """
-        
+
         when:
         def result = runTasks('checkConfig')
-        
+
         then:
         result.output.contains('lockFile: custom.lock')
         result.output.contains('includeTransitives: true')
         result.output.contains('lockAfterEvaluating: false')
     }
-    
+
     def 'extension properties can be configured via Groovy shorthand'() {
         given:
         buildFile << """
             plugins {
                 id 'com.netflix.nebula.dependency-lock'
             }
-            
+
             dependencyLock {
                 lockFile = 'shorthand.lock'  // Groovy property shorthand
                 includeTransitives = true
             }
-            
+
             task checkConfig {
                 def ext = dependencyLock  // Capture during configuration
                 doLast {
@@ -87,28 +87,28 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
                 }
             }
         """
-        
+
         when:
         def result = runTasks('checkConfig')
-        
+
         then:
         result.output.contains('lockFile: shorthand.lock')
         result.output.contains('includeTransitives: true')
     }
-    
+
     def 'set properties work with lazy evaluation'() {
         given:
         buildFile << """
             plugins {
                 id 'com.netflix.nebula.dependency-lock'
             }
-            
+
             dependencyLock {
                 configurationNames.add('runtimeClasspath')
                 configurationNames.add('compileClasspath')
                 skippedDependencies.add('com.example:skip-me')
             }
-            
+
             task checkConfig {
                 def ext = dependencyLock  // Capture during configuration
                 doLast {
@@ -117,23 +117,23 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
                 }
             }
         """
-        
+
         when:
         def result = runTasks('checkConfig')
-        
+
         then:
         result.output.contains('runtimeClasspath')
         result.output.contains('compileClasspath')
         result.output.contains('skip-me')
     }
-    
+
     def 'commit extension properties use default conventions'() {
         given:
         buildFile << """
             plugins {
                 id 'com.netflix.nebula.dependency-lock'
             }
-            
+
             task checkDefaults {
                 def ext = commitDependencyLock  // Capture during configuration
                 doLast {
@@ -144,31 +144,31 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
                 }
             }
         """
-        
+
         when:
         def result = runTasks('checkDefaults')
-        
+
         then:
         result.output.contains('message: Committing dependency lock files')
         result.output.contains('shouldCreateTag: false')
         result.output.contains('remoteRetries: 3')
         result.output.contains('tag: LockCommit-')
     }
-    
+
     def 'commit extension properties can be configured'() {
         given:
         buildFile << """
             plugins {
                 id 'com.netflix.nebula.dependency-lock'
             }
-            
+
             commitDependencyLock {
                 message = 'Custom commit message'
                 shouldCreateTag = true
                 tag = 'v1.0.0'
                 remoteRetries = 5
             }
-            
+
             task checkConfig {
                 def ext = commitDependencyLock  // Capture during configuration
                 doLast {
@@ -179,15 +179,16 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
                 }
             }
         """
-        
+
         when:
         def result = runTasks('checkConfig')
-        
+
         then:
         result.output.contains('message: Custom commit message')
         result.output.contains('shouldCreateTag: true')
         result.output.contains('tag: v1.0.0')
         result.output.contains('remoteRetries: 5')
     }
+
 }
 

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
@@ -104,15 +104,15 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
             }
 
             dependencyLock {
-                configurationNames.add('runtimeClasspath')
-                configurationNames.add('compileClasspath')
+                configurationNamesProperty.add('runtimeClasspath')
+                configurationNamesProperty.add('compileClasspath')
                 skippedDependenciesProperty.add('com.example:skip-me')
             }
 
             task checkConfig {
                 def ext = dependencyLock  // Capture during configuration
                 doLast {
-                    println "configs: " + ext.configurationNames.get()
+                    println "configs: " + ext.configurationNames
                     println "skipped: " + ext.skippedDependencies
                 }
             }
@@ -285,6 +285,161 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
         then:
         result.output.contains('test')
         result.output.contains('runtime')
+    }
+
+    def 'configurationNames supports Groovy = assignment (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            dependencyLock {
+                configurationNames = ['runtimeClasspath', 'compileClasspath'] as Set
+            }
+
+            task checkConfig {
+                def ext = dependencyLock
+                doLast {
+                    println "configs: " + ext.configurationNames
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkConfig')
+
+        then:
+        result.output.contains('runtimeClasspath')
+        result.output.contains('compileClasspath')
+    }
+
+    def 'configurationNames getter returns Set not SetProperty'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            task checkType {
+                def ext = dependencyLock
+                doLast {
+                    def value = ext.configurationNames
+                    println "isSet: " + (value instanceof Set)
+                    println "isSetProperty: " + value.getClass().name.contains('SetProperty')
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkType')
+
+        then:
+        result.output.contains('isSet: true')
+        result.output.contains('isSetProperty: false')
+    }
+
+    def 'updateDependencies supports Groovy = assignment (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            dependencyLock {
+                updateDependencies = ['com.example:foo', 'com.example:bar'] as Set
+            }
+
+            task checkUpdate {
+                def ext = dependencyLock
+                doLast {
+                    println "updates: " + ext.updateDependencies
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkUpdate')
+
+        then:
+        result.output.contains('com.example:foo')
+        result.output.contains('com.example:bar')
+    }
+
+    def 'updateDependencies getter returns Set not SetProperty'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            task checkType {
+                def ext = dependencyLock
+                doLast {
+                    def value = ext.updateDependencies
+                    println "isSet: " + (value instanceof Set)
+                    println "isSetProperty: " + value.getClass().name.contains('SetProperty')
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkType')
+
+        then:
+        result.output.contains('isSet: true')
+        result.output.contains('isSetProperty: false')
+    }
+
+    def 'additionalConfigurationsToLock supports Groovy = assignment (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            dependencyLock {
+                additionalConfigurationsToLock = ['annotationProcessor'] as Set
+            }
+
+            task checkAdditional {
+                def ext = dependencyLock
+                doLast {
+                    println "additional: " + ext.additionalConfigurationsToLock
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkAdditional')
+
+        then:
+        result.output.contains('annotationProcessor')
+    }
+
+    def 'additionalConfigurationsToLock getter returns Set not SetProperty'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            task checkType {
+                def ext = dependencyLock
+                doLast {
+                    def value = ext.additionalConfigurationsToLock
+                    println "isSet: " + (value instanceof Set)
+                    println "isSetProperty: " + value.getClass().name.contains('SetProperty')
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkType')
+
+        then:
+        result.output.contains('isSet: true')
+        result.output.contains('isSetProperty: false')
     }
 
     def 'commit extension properties use default conventions'() {

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockExtensionPropertySpec.groovy
@@ -19,8 +19,8 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
                 doLast {
                     println "lockFile: " + ext.lockFile
                     println "globalLockFile: " + ext.globalLockFile
-                    println "includeTransitives: " + ext.includeTransitives.get()
-                    println "lockAfterEvaluating: " + ext.lockAfterEvaluating.get()
+                    println "includeTransitives: " + ext.includeTransitives
+                    println "lockAfterEvaluating: " + ext.lockAfterEvaluating
                 }
             }
         """
@@ -44,16 +44,16 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
 
             dependencyLock {
                 lockFileProperty.set('custom.lock')
-                includeTransitives.set(true)
-                lockAfterEvaluating.set(false)
+                includeTransitivesProperty.set(true)
+                lockAfterEvaluatingProperty.set(false)
             }
 
             task checkConfig {
                 def ext = dependencyLock  // Capture during configuration
                 doLast {
                     println "lockFile: " + ext.lockFile
-                    println "includeTransitives: " + ext.includeTransitives.get()
-                    println "lockAfterEvaluating: " + ext.lockAfterEvaluating.get()
+                    println "includeTransitives: " + ext.includeTransitives
+                    println "lockAfterEvaluating: " + ext.lockAfterEvaluating
                 }
             }
         """
@@ -83,7 +83,7 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
                 def ext = dependencyLock  // Capture during configuration
                 doLast {
                     println "lockFile: " + ext.lockFile
-                    println "includeTransitives: " + ext.includeTransitives.get()
+                    println "includeTransitives: " + ext.includeTransitives
                 }
             }
         """
@@ -538,6 +538,104 @@ class DependencyLockExtensionPropertySpec extends BaseIntegrationTestKitSpec {
 
         then:
         result.output.contains('globalLockFile: custom-global.lock')
+    }
+
+    def 'includeTransitives getter returns Boolean not Property (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            task checkType {
+                def ext = dependencyLock
+                doLast {
+                    def value = ext.includeTransitives
+                    println "isBoolean: " + (value instanceof Boolean)
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkType')
+
+        then:
+        result.output.contains('isBoolean: true')
+    }
+
+    def 'includeTransitives supports Groovy = assignment (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            dependencyLock {
+                includeTransitives = true
+            }
+
+            task checkConfig {
+                def ext = dependencyLock
+                doLast {
+                    println "includeTransitives: " + ext.includeTransitives
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkConfig')
+
+        then:
+        result.output.contains('includeTransitives: true')
+    }
+
+    def 'lockAfterEvaluating getter returns Boolean not Property (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            task checkType {
+                def ext = dependencyLock
+                doLast {
+                    def value = ext.lockAfterEvaluating
+                    println "isBoolean: " + (value instanceof Boolean)
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkType')
+
+        then:
+        result.output.contains('isBoolean: true')
+    }
+
+    def 'lockAfterEvaluating supports Groovy = assignment (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            dependencyLock {
+                lockAfterEvaluating = false
+            }
+
+            task checkConfig {
+                def ext = dependencyLock
+                doLast {
+                    println "lockAfterEvaluating: " + ext.lockAfterEvaluating
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkConfig')
+
+        then:
+        result.output.contains('lockAfterEvaluating: false')
     }
 
     def 'commit extension properties use default conventions'() {

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
@@ -34,7 +34,7 @@ import java.nio.file.Paths
 class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
 
     @Rule
-    public final ProvideSystemProperty provideSystemProperty = new ProvideSystemProperty("ignoreDeprecations", "false")
+    public final ProvideSystemProperty provideSystemProperty = new ProvideSystemProperty('ignoreDeprecations', 'false')
 
     def setup() {
         definePluginOutsideOfPluginBlock = true
@@ -320,11 +320,11 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
 
     def 'lock file name can be customized'() {
         buildFile << BUILD_GRADLE
-        buildFile << """
+        buildFile << '''
         dependencyLock {
             lockFile = "custom.lock"
         }
-        """
+        '''
 
         when:
         def result = runTasks('generateLock', 'saveLock')
@@ -407,7 +407,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
         runTasks('generateLock')
 
         then:
-        new File(projectDir, 'build/dependencies.lock').text.replaceAll("\\s", "") == lockWithSkips.replaceAll("\\s", "")
+        new File(projectDir, 'build/dependencies.lock').text.replaceAll('\\s', '') == lockWithSkips.replaceAll('\\s', '')
     }
 
     def 'update lock'() {
@@ -528,7 +528,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
         def result = runTasksAndFail('updateLock', 'saveLock')
 
         then:
-        result.output.contains("Usage of `updateLock` task requires specific modules to update. Please specify dependencies to update")
+        result.output.contains('Usage of `updateLock` task requires specific modules to update. Please specify dependencies to update')
     }
 
     def 'update lock uses property when intending to run with no dependencies to update passed in'() {
@@ -649,14 +649,14 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
                     "viaOverride": "2.0.0"
                 }
             '''.stripIndent())
-        new File(sub1, 'dependencies.lock').text.replaceAll("\\s", "") == lockText1.replaceAll("\\s", "")
+        new File(sub1, 'dependencies.lock').text.replaceAll('\\s', '') == lockText1.replaceAll('\\s', '')
         String lockText2 = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly('''\
                 "test.example:baz": {
                     "locked": "1.0.0",
                     "viaOverride": "1.0.0"
                 }
             '''.stripIndent())
-        new File(sub2, 'dependencies.lock').text.replaceAll("\\s", "") == lockText2.replaceAll("\\s", "")
+        new File(sub2, 'dependencies.lock').text.replaceAll('\\s', '') == lockText2.replaceAll('\\s', '')
     }
 
     def 'in multiproject allow applying to root project'() {
@@ -676,7 +676,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
     }
 
     def 'create global lock in singleproject'() {
-        provideSystemProperty.setProperty("ignoreDeprecations", "true")
+        provideSystemProperty.setProperty('ignoreDeprecations', 'true')
         buildFile << BUILD_GRADLE
 
         when:
@@ -686,9 +686,8 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
         new File(projectDir, 'build/global.lock').text == FOO_LOCK
     }
 
-
     def 'warn the user when configurations for creating global lock in multiproject are no longer resolvable, thus no longer lockable'() {
-        provideSystemProperty.setProperty("ignoreDeprecations", "true")
+        provideSystemProperty.setProperty('ignoreDeprecations', 'true')
         disableConfigurationCache()
         addSubproject('sub1', """\
             configurations {
@@ -716,7 +715,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
         """.stripIndent()
 
         when:
-        def result =runTasks('generateGlobalLock', '--warning-mode', 'all')
+        def result = runTasks('generateGlobalLock', '--warning-mode', 'all')
 
         then:
         assert result.output.contains('Global lock warning: project \'sub1\' requested locking a configuration which cannot be consumed: \'compileClasspath\'')
@@ -731,7 +730,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
     }
 
     def 'save global lock in multiproject'() {
-        provideSystemProperty.setProperty("ignoreDeprecations", "true")
+        provideSystemProperty.setProperty('ignoreDeprecations', 'true')
         disableConfigurationCache()
         setupCommonMultiproject()
 
@@ -779,13 +778,13 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
                     "locked": "2.0.0"
                 }
             '''.stripIndent())
-        new File(projectDir, 'sub1/dependencies.lock').text.replaceAll("\\s", "") == lockText1.replaceAll("\\s", "")
+        new File(projectDir, 'sub1/dependencies.lock').text.replaceAll('\\s', '') == lockText1.replaceAll('\\s', '')
         String lockText2 = LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly('''\
                 "test.example:foo": {
                     "locked": "1.0.1"
                 }
             '''.stripIndent())
-        new File(projectDir, 'sub2/dependencies.lock').text.replaceAll("\\s", "") == lockText2.replaceAll("\\s", "")
+        new File(projectDir, 'sub2/dependencies.lock').text.replaceAll('\\s', '') == lockText2.replaceAll('\\s', '')
     }
 
     def 'diffLock in multiproject'() {
@@ -837,7 +836,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
     }
 
     def 'generateGlobalLock ignores existing global lock file'() {
-        provideSystemProperty.setProperty("ignoreDeprecations", "true")
+        provideSystemProperty.setProperty('ignoreDeprecations', 'true')
         disableConfigurationCache()
         setupCommonMultiproject()
         new File(projectDir, 'global.lock').text = '''\
@@ -1202,10 +1201,9 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
         when:
         def result = runTasksAndFail('-PdependencyLock.updateDependencies=test.example:foo:2.0.1', '-PdependencyLock.override=test.example:foo:2.0.1', 'updateLock', 'saveLock')
 
-
         then:
-        result.output.contains("updateDependencies list is invalid")
-        result.output.contains("test.example:foo:2.0.1 contains more elements than groupId:module")
+        result.output.contains('updateDependencies list is invalid')
+        result.output.contains('test.example:foo:2.0.1 contains more elements than groupId:module')
     }
 
     def 'command line override respected while updating lock with malformed coordinates with extension'() {
@@ -1320,10 +1318,10 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
     }
 
     //Spring boot plugin 1.x is using removed runtime configuration. Unless backported for Gradle 7.0 it cannot be used
-    @IgnoreIf({ GradleVersion.current().baseVersion >= GradleVersion.version("7.0")})
+    @IgnoreIf({ GradleVersion.current().baseVersion >= GradleVersion.version('7.0') })
     @Issue('#86')
     def 'locks win over Spring dependency management'() {
-        provideSystemProperty.setProperty("ignoreDeprecations", "true")
+        provideSystemProperty.setProperty('ignoreDeprecations', 'true')
         // Deprecation: The classifier property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the archiveClassifier property instead.
 
         buildFile << """\
@@ -1426,8 +1424,8 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
 
         then: 'all configurations are in the lock file'
         def configList = generateResult.output.readLines().find {
-            it.startsWith("configurations=")
-        }.split("configurations=")[1]
+            it.startsWith('configurations=')
+        }.split('configurations=')[1]
         def configurations = Eval.me(configList)
         def lockFile = new File(projectDir, 'dependencies.lock')
         def json = new JsonSlurper().parseText(lockFile.text)
@@ -1452,7 +1450,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
 
     def 'deprecated lock format message is not output for an empty file'() {
         def dependenciesLock = new File(projectDir, 'dependencies.lock')
-        dependenciesLock << """{}"""
+        dependenciesLock << '''{}'''
 
         buildFile << BUILD_GRADLE
 
@@ -1460,7 +1458,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
         def result = runTasks('dependencies')
 
         then:
-        !result.output.contains("is using a deprecated lock format")
+        !result.output.contains('is using a deprecated lock format')
     }
 
     @Unroll
@@ -1486,7 +1484,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
             allprojects {
                 apply plugin: 'com.netflix.nebula.dependency-lock'
             }
-            
+
             subprojects {
                 repositories { mavenCentral() }
             }
@@ -1503,7 +1501,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
     }
 
     def 'global lock with skippedConfigurationNamesPrefixes'() {
-        provideSystemProperty.setProperty("ignoreDeprecations", "true")
+        provideSystemProperty.setProperty('ignoreDeprecations', 'true')
         disableConfigurationCache()
         addSubproject('one')
         addSubproject('two')
@@ -1514,9 +1512,9 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
                 dependencyLock {
                     skippedConfigurationNamesPrefixes = ['spotless']
                 }
-                
+
             }
-            
+
             subprojects {
                 apply plugin: 'java'
                 repositories { mavenCentral() }
@@ -1533,7 +1531,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
         when:
         def result = runTasks('generateGlobalLock', 'saveGlobalLock')
 
-        then: "Guava is locked to 19.0"
+        then: 'Guava is locked to 19.0'
         new File(projectDir, 'global.lock').text == """{
     "_global_": {
         "com.google.guava:guava": {
@@ -1556,8 +1554,8 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
         def resultDependencies = runTasks(':one:dependencies')
 
         then:
-        resultDependencies.output.contains("com.google.guava:guava:31.1-jre")
-        !resultDependencies.output.contains("com.google.guava:guava:31.1-jre -> 19.0")
+        resultDependencies.output.contains('com.google.guava:guava:31.1-jre')
+        !resultDependencies.output.contains('com.google.guava:guava:31.1-jre -> 19.0')
     }
 
     def 'handle generating a lock with circular dependencies depending on a jar that depends on us'() {
@@ -1573,7 +1571,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
             group = 'example.nebula'
             version = '1.1.0'
             apply plugin: 'com.netflix.nebula.dependency-lock'
-            
+
             repositories {
                 ${generator.mavenRepositoryBlock}
             }
@@ -1619,7 +1617,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
             group = 'example.nebula'
             version = '1.1.0'
             apply plugin: 'com.netflix.nebula.dependency-lock'
-            
+
             repositories {
                 ${generator.mavenRepositoryBlock}
             }
@@ -1718,8 +1716,8 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
             subprojects {
                 apply plugin: 'scala'
                 apply plugin: "com.github.spotbugs"
-                repositories { 
-                    maven { url = '${Fixture.repo}' } 
+                repositories {
+                    maven { url = '${Fixture.repo}' }
                     mavenCentral()
                 }
             }
@@ -1764,7 +1762,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
                 id 'java'
             }
             apply plugin: 'com.netflix.nebula.dependency-lock'
-            
+
             repositories {
                 ${generator.mavenRepositoryBlock}
             }
@@ -1799,7 +1797,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
                 id 'java'
             }
             apply plugin: 'com.netflix.nebula.dependency-lock'
-            
+
             repositories {
                 ${generator.mavenRepositoryBlock}
             }
@@ -1829,7 +1827,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
     }
 
     def 'save global lock in multiproject - do not lock excluded configurations'() {
-        provideSystemProperty.setProperty("ignoreDeprecations", "true")
+        provideSystemProperty.setProperty('ignoreDeprecations', 'true')
         disableConfigurationCache()
         setupCommonMultiprojectWithPlugins()
 
@@ -1879,8 +1877,8 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
         }
         '''.stripIndent()
 
-        def repo = new File(projectDir,'repo')
-        
+        def repo = new File(projectDir, 'repo')
+
         // Create version 1.0
         def sample = new File(repo, 'sample/recommender/1.0')
         sample.mkdirs()
@@ -1904,7 +1902,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
               </dependencyManagement>
             </project>
         '''
-        
+
         // Create version 1.1 (requested in build but will be locked to 1.0)
         def sample11 = new File(repo, 'sample/recommender/1.1')
         sample11.mkdirs()
@@ -1994,7 +1992,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
             }
             """.stripIndent()
 
-        when: "show configurations and ensure that the *DependenciesMetadata configurations exist"
+        when: 'show configurations and ensure that the *DependenciesMetadata configurations exist'
         def result = runTasks('dependencies')
 
         then:
@@ -2005,10 +2003,10 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
         result.output.contains('testCompileOnlyDependenciesMetadata')
         result.output.contains('testImplementationDependenciesMetadata')
 
-        when: "update locks"
+        when: 'update locks'
         runTasks('generateLock', 'saveLock')
 
-        then: "lockfile should not contain *DependenciesMetadata configurations"
+        then: 'lockfile should not contain *DependenciesMetadata configurations'
         def lockFile = new File(projectDir, 'dependencies.lock')
         !lockFile.text.contains('implementationDependenciesMetadata')
         lockFile.text.contains('org.jetbrains.kotlin:kotlin-stdlib')
@@ -2056,10 +2054,11 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
                     "locked": "2.0.0"
                 }
             '''.stripIndent())
-        new File(projectDir, 'sub1/dependencies.lock').text.replaceAll("\\s", "") == lockText1.replaceAll("\\s", "")
+        new File(projectDir, 'sub1/dependencies.lock').text.replaceAll('\\s', '') == lockText1.replaceAll('\\s', '')
 
         and: 'global lock tasks are not created'
         !result.output.contains('generateGlobalLock')
         !result.output.contains('saveGlobalLock')
     }
+
 }

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
@@ -220,6 +220,21 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
         bazResult.output.contains('baz:1.0.0')
     }
 
+    def 'malformed dependencyLock.override coordinate without version logs warning and does not crash'() {
+        def dependenciesLock = new File(projectDir, 'dependencies.lock')
+        dependenciesLock << OLD_FOO_LOCK
+
+        buildFile << SPECIFIC_BUILD_GRADLE
+
+        when: 'override missing version component should warn and be skipped, not crash'
+        def result = runTasks('dependencyInsight', '--configuration', 'compileClasspath', '--dependency', 'foo',
+            '-PdependencyLock.override=test.example:foo')
+
+        then:
+        !result.output.contains('FAILURE')
+        result.output.contains('Invalid override')
+    }
+
     @Issue('#79')
     def 'lock file is not applied while generating lock with abbreviated task name'() {
         def dependenciesLock = new File(projectDir, 'dependencies.lock')

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
@@ -2061,4 +2061,37 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
         !result.output.contains('saveGlobalLock')
     }
 
+    def 'global lock respects skippedDependencies configured via bridge setter'() {
+        provideSystemProperty.setProperty('ignoreDeprecations', 'true')
+        disableConfigurationCache()
+        addSubproject('sub1', """\
+            dependencies {
+                implementation 'test.example:foo:2.+'
+                implementation 'test.example:baz:1.+'
+            }
+        """.stripIndent())
+
+        buildFile << """\
+            allprojects {
+                apply plugin: 'com.netflix.nebula.dependency-lock'
+                group = 'test'
+                dependencyLock {
+                    skippedDependencies = ['test.example:foo']
+                }
+            }
+            subprojects {
+                apply plugin: 'java'
+                repositories { maven { url = '${Fixture.repo}' } }
+            }
+        """.stripIndent()
+
+        when:
+        runTasks('generateGlobalLock', 'saveGlobalLock')
+
+        then:
+        def lock = new File(projectDir, 'global.lock').text
+        !lock.contains('test.example:foo')
+        lock.contains('test.example:baz')
+    }
+
 }

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockReaderSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockReaderSpec.groovy
@@ -1,6 +1,7 @@
 package nebula.plugin.dependencylock
 
 class DependencyLockReaderSpec extends FreshProjectSpec {
+
     def 'read global lock with an extraneous transitive that is not in the lock due to manual editing'() {
         project.plugins.apply('java')
         DependencyLockReader reader = new DependencyLockReader(project)
@@ -27,4 +28,5 @@ class DependencyLockReaderSpec extends FreshProjectSpec {
         then:
         noExceptionThrown()
     }
+
 }

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockReaderSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockReaderSpec.groovy
@@ -1,6 +1,20 @@
 package nebula.plugin.dependencylock
 
+
 class DependencyLockReaderSpec extends FreshProjectSpec {
+
+    def 'parseLockFile with null JSON content returns empty map rather than null'() {
+        project.plugins.apply('java')
+        DependencyLockReader reader = new DependencyLockReader(project)
+        File lock = new File(projectDir, 'dependencies.lock')
+        lock.text = 'null'
+
+        when:
+        reader.readLocks(project.configurations.compileClasspath, lock, [:])
+
+        then:
+        noExceptionThrown()
+    }
 
     def 'read global lock with an extraneous transitive that is not in the lock due to manual editing'() {
         project.plugins.apply('java')

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockReaderSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockReaderSpec.groovy
@@ -1,9 +1,10 @@
 package nebula.plugin.dependencylock
 
+import org.gradle.api.GradleException
 
 class DependencyLockReaderSpec extends FreshProjectSpec {
 
-    def 'parseLockFile with null JSON content returns empty map rather than null'() {
+    def 'parseLockFile with null JSON content throws GradleException rather than silently treating locks as empty'() {
         project.plugins.apply('java')
         DependencyLockReader reader = new DependencyLockReader(project)
         File lock = new File(projectDir, 'dependencies.lock')
@@ -13,7 +14,8 @@ class DependencyLockReaderSpec extends FreshProjectSpec {
         reader.readLocks(project.configurations.compileClasspath, lock, [:])
 
         then:
-        noExceptionThrown()
+        def ex = thrown(GradleException)
+        ex.message.contains('dependencies.lock')
     }
 
     def 'read global lock with an extraneous transitive that is not in the lock due to manual editing'() {

--- a/src/test/groovy/nebula/plugin/dependencylock/validation/UpdateDependenciesValidatorSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/validation/UpdateDependenciesValidatorSpec.groovy
@@ -19,9 +19,9 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
         when:
         Set<String> modules = ['netflix:my-module', 'netflix:my-module-2']
         UpdateDependenciesValidator.validate(modules, emptyMap, true, false,
-            extension.updateDependenciesFailOnInvalidCoordinates.get(),
-            extension.updateDependenciesFailOnSimultaneousTaskUsage.get(),
-            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate.get())
+            extension.updateDependenciesFailOnInvalidCoordinates,
+            extension.updateDependenciesFailOnSimultaneousTaskUsage,
+            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate)
 
         then:
         notThrown(DependencyLockException)
@@ -31,9 +31,9 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
         when:
         Set<String> modules = ['netflix', 'netflix:my-module:1.+', 'netflix:my-module-2:latest.release', 'netflix:my-module;2:latest.release']
         UpdateDependenciesValidator.validate(modules, emptyMap, true, false,
-            extension.updateDependenciesFailOnInvalidCoordinates.get(),
-            extension.updateDependenciesFailOnSimultaneousTaskUsage.get(),
-            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate.get())
+            extension.updateDependenciesFailOnInvalidCoordinates,
+            extension.updateDependenciesFailOnSimultaneousTaskUsage,
+            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate)
 
         then:
         def exception = thrown(DependencyLockException)
@@ -48,13 +48,12 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
         when:
         project.ext.set('dependencyLock.updateDependenciesFailOnInvalidCoordinates', false)
         Set<String> modules = ['netflix', 'netflix:my-module:1.+', 'netflix:my-module-2:latest.release', 'netflix:my-module;2:latest.release']
-        // Use findProperty to check both gradle properties and ext (check for null, not truthiness)
         def validateCoordinatesProp = project.findProperty('dependencyLock.updateDependenciesFailOnInvalidCoordinates')
-        def validateCoordinates = validateCoordinatesProp != null ? validateCoordinatesProp as boolean : extension.updateDependenciesFailOnInvalidCoordinates.get()
+        def validateCoordinates = validateCoordinatesProp != null ? validateCoordinatesProp as boolean : extension.updateDependenciesFailOnInvalidCoordinates
         UpdateDependenciesValidator.validate(modules, emptyMap, true, false,
             validateCoordinates,
-            extension.updateDependenciesFailOnSimultaneousTaskUsage.get(),
-            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate.get())
+            extension.updateDependenciesFailOnSimultaneousTaskUsage,
+            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate)
 
         then:
         notThrown(DependencyLockException)
@@ -64,9 +63,9 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
         when:
         Set<String> modules = []
         UpdateDependenciesValidator.validate(modules, emptyMap, false, true,
-            extension.updateDependenciesFailOnInvalidCoordinates.get(),
-            extension.updateDependenciesFailOnSimultaneousTaskUsage.get(),
-            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate.get())
+            extension.updateDependenciesFailOnInvalidCoordinates,
+            extension.updateDependenciesFailOnSimultaneousTaskUsage,
+            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate)
 
         then:
         notThrown(DependencyLockException)
@@ -76,9 +75,9 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
         when:
         Set<String> modules = ['netflix:my-module', 'netflix:my-module-2']
         UpdateDependenciesValidator.validate(modules, emptyMap, true, false,
-            extension.updateDependenciesFailOnInvalidCoordinates.get(),
-            extension.updateDependenciesFailOnSimultaneousTaskUsage.get(),
-            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate.get())
+            extension.updateDependenciesFailOnInvalidCoordinates,
+            extension.updateDependenciesFailOnSimultaneousTaskUsage,
+            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate)
 
         then:
         notThrown(DependencyLockException)
@@ -88,9 +87,9 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
         when:
         Set<String> modules = ['netflix:my-module', 'netflix:my-module-2']
         UpdateDependenciesValidator.validate(modules, emptyMap, true, true,
-            extension.updateDependenciesFailOnInvalidCoordinates.get(),
-            extension.updateDependenciesFailOnSimultaneousTaskUsage.get(),
-            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate.get())
+            extension.updateDependenciesFailOnInvalidCoordinates,
+            extension.updateDependenciesFailOnSimultaneousTaskUsage,
+            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate)
 
         then:
         def exception = thrown(DependencyLockException)
@@ -102,13 +101,12 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
         when:
         project.ext.set('dependencyLock.updateDependenciesFailOnSimultaneousTaskUsage', false)
         Set<String> modules = ['netflix:my-module', 'netflix:my-module-2']
-        // Use findProperty to check both gradle properties and ext (check for null, not truthiness)
         def validateSimultaneousProp = project.findProperty('dependencyLock.updateDependenciesFailOnSimultaneousTaskUsage')
-        def validateSimultaneous = validateSimultaneousProp != null ? validateSimultaneousProp as boolean : extension.updateDependenciesFailOnSimultaneousTaskUsage.get()
+        def validateSimultaneous = validateSimultaneousProp != null ? validateSimultaneousProp as boolean : extension.updateDependenciesFailOnSimultaneousTaskUsage
         UpdateDependenciesValidator.validate(modules, emptyMap, true, true,
-            extension.updateDependenciesFailOnInvalidCoordinates.get(),
+            extension.updateDependenciesFailOnInvalidCoordinates,
             validateSimultaneous,
-            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate.get())
+            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate)
 
         then:
         notThrown(DependencyLockException)
@@ -121,9 +119,9 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
         overrides.put('netflix:my-module', '1.0.0')
         overrides.put('netflix:my-module-2', '1.0.0')
         UpdateDependenciesValidator.validate(modules, overrides, true, false,
-            extension.updateDependenciesFailOnInvalidCoordinates.get(),
-            extension.updateDependenciesFailOnSimultaneousTaskUsage.get(),
-            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate.get())
+            extension.updateDependenciesFailOnInvalidCoordinates,
+            extension.updateDependenciesFailOnSimultaneousTaskUsage,
+            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate)
 
         then:
         notThrown(DependencyLockException)
@@ -133,9 +131,9 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
         when:
         Set<String> modules = []
         UpdateDependenciesValidator.validate(modules, emptyMap, true, false,
-            extension.updateDependenciesFailOnInvalidCoordinates.get(),
-            extension.updateDependenciesFailOnSimultaneousTaskUsage.get(),
-            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate.get())
+            extension.updateDependenciesFailOnInvalidCoordinates,
+            extension.updateDependenciesFailOnSimultaneousTaskUsage,
+            extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate)
 
         then:
         def exception = thrown(DependencyLockException)
@@ -146,12 +144,11 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
         when:
         project.ext.set('dependencyLock.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate', false)
         Set<String> modules = []
-        // Use findProperty to check both gradle properties and ext (check for null, not truthiness)
         def validateSpecifiedProp = project.findProperty('dependencyLock.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate')
-        def validateSpecified = validateSpecifiedProp != null ? validateSpecifiedProp as boolean : extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate.get()
+        def validateSpecified = validateSpecifiedProp != null ? validateSpecifiedProp as boolean : extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate
         UpdateDependenciesValidator.validate(modules, emptyMap, true, false,
-            extension.updateDependenciesFailOnInvalidCoordinates.get(),
-            extension.updateDependenciesFailOnSimultaneousTaskUsage.get(),
+            extension.updateDependenciesFailOnInvalidCoordinates,
+            extension.updateDependenciesFailOnSimultaneousTaskUsage,
             validateSpecified)
 
         then:

--- a/src/test/groovy/nebula/plugin/dependencylock/validation/UpdateDependenciesValidatorSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/validation/UpdateDependenciesValidatorSpec.groovy
@@ -5,6 +5,7 @@ import nebula.plugin.dependencylock.exceptions.DependencyLockException
 import nebula.plugin.dependencylock.FreshProjectSpec
 
 class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
+
     private static final HashMap<Object, Object> emptyMap = new HashMap<Object, Object>()
     private static final String pluginName = 'com.netflix.nebula.dependency-lock'
     DependencyLockExtension extension
@@ -16,8 +17,8 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
 
     def 'should not fail if valid coordinates'() {
         when:
-        Set<String> modules = ["netflix:my-module", "netflix:my-module-2"]
-        UpdateDependenciesValidator.validate(modules, emptyMap, true, false, 
+        Set<String> modules = ['netflix:my-module', 'netflix:my-module-2']
+        UpdateDependenciesValidator.validate(modules, emptyMap, true, false,
             extension.updateDependenciesFailOnInvalidCoordinates.get(),
             extension.updateDependenciesFailOnSimultaneousTaskUsage.get(),
             extension.updateDependenciesFailOnNonSpecifiedDependenciesToUpdate.get())
@@ -28,7 +29,7 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
 
     def 'should fail if invalid coordinates'() {
         when:
-        Set<String> modules = ["netflix", "netflix:my-module:1.+", "netflix:my-module-2:latest.release", "netflix:my-module;2:latest.release"]
+        Set<String> modules = ['netflix', 'netflix:my-module:1.+', 'netflix:my-module-2:latest.release', 'netflix:my-module;2:latest.release']
         UpdateDependenciesValidator.validate(modules, emptyMap, true, false,
             extension.updateDependenciesFailOnInvalidCoordinates.get(),
             extension.updateDependenciesFailOnSimultaneousTaskUsage.get(),
@@ -36,17 +37,17 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
 
         then:
         def exception = thrown(DependencyLockException)
-        exception.message.contains("netflix does not contain groupId:module. Only has one element")
-        exception.message.contains("netflix:my-module:1.+ contains more elements than groupId:module. Version and classifiers are not supported")
-        exception.message.contains("netflix:my-module-2:latest.release contains more elements than groupId:module. Version and classifiers are not supported")
-        exception.message.contains("netflix:my-module;2:latest.release contains more elements than groupId:module. Version and classifiers are not supported")
-        exception.message.contains("netflix:my-module;2:latest.release contains ; which is invalid")
+        exception.message.contains('netflix does not contain groupId:module. Only has one element')
+        exception.message.contains('netflix:my-module:1.+ contains more elements than groupId:module. Version and classifiers are not supported')
+        exception.message.contains('netflix:my-module-2:latest.release contains more elements than groupId:module. Version and classifiers are not supported')
+        exception.message.contains('netflix:my-module;2:latest.release contains more elements than groupId:module. Version and classifiers are not supported')
+        exception.message.contains('netflix:my-module;2:latest.release contains ; which is invalid')
     }
 
     def 'should not fail if invalid coordinates but disabled validation'() {
         when:
         project.ext.set('dependencyLock.updateDependenciesFailOnInvalidCoordinates', false)
-        Set<String> modules = ["netflix", "netflix:my-module:1.+", "netflix:my-module-2:latest.release", "netflix:my-module;2:latest.release"]
+        Set<String> modules = ['netflix', 'netflix:my-module:1.+', 'netflix:my-module-2:latest.release', 'netflix:my-module;2:latest.release']
         // Use findProperty to check both gradle properties and ext (check for null, not truthiness)
         def validateCoordinatesProp = project.findProperty('dependencyLock.updateDependenciesFailOnInvalidCoordinates')
         def validateCoordinates = validateCoordinatesProp != null ? validateCoordinatesProp as boolean : extension.updateDependenciesFailOnInvalidCoordinates.get()
@@ -73,7 +74,7 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
 
     def 'should not fail when calling one locking generation command - updateLock'() {
         when:
-        Set<String> modules = ["netflix:my-module", "netflix:my-module-2"]
+        Set<String> modules = ['netflix:my-module', 'netflix:my-module-2']
         UpdateDependenciesValidator.validate(modules, emptyMap, true, false,
             extension.updateDependenciesFailOnInvalidCoordinates.get(),
             extension.updateDependenciesFailOnSimultaneousTaskUsage.get(),
@@ -85,7 +86,7 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
 
     def 'should fail when calling generateLock and updateLock together'() {
         when:
-        Set<String> modules = ["netflix:my-module", "netflix:my-module-2"]
+        Set<String> modules = ['netflix:my-module', 'netflix:my-module-2']
         UpdateDependenciesValidator.validate(modules, emptyMap, true, true,
             extension.updateDependenciesFailOnInvalidCoordinates.get(),
             extension.updateDependenciesFailOnSimultaneousTaskUsage.get(),
@@ -93,14 +94,14 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
 
         then:
         def exception = thrown(DependencyLockException)
-        exception.message.contains("Using `generateLock` and `updateLock` in the same build will result in re-resolving all locked dependencies.")
-        exception.message.contains("Please invoke only one of these tasks at a time.")
+        exception.message.contains('Using `generateLock` and `updateLock` in the same build will result in re-resolving all locked dependencies.')
+        exception.message.contains('Please invoke only one of these tasks at a time.')
     }
 
     def 'should not fail when calling generateLock and updateLock together but disabled validation'() {
         when:
         project.ext.set('dependencyLock.updateDependenciesFailOnSimultaneousTaskUsage', false)
-        Set<String> modules = ["netflix:my-module", "netflix:my-module-2"]
+        Set<String> modules = ['netflix:my-module', 'netflix:my-module-2']
         // Use findProperty to check both gradle properties and ext (check for null, not truthiness)
         def validateSimultaneousProp = project.findProperty('dependencyLock.updateDependenciesFailOnSimultaneousTaskUsage')
         def validateSimultaneous = validateSimultaneousProp != null ? validateSimultaneousProp as boolean : extension.updateDependenciesFailOnSimultaneousTaskUsage.get()
@@ -117,8 +118,8 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
         when:
         Set<String> modules = []
         Map<String, String> overrides = new HashMap<>()
-        overrides.put("netflix:my-module", "1.0.0")
-        overrides.put("netflix:my-module-2", "1.0.0")
+        overrides.put('netflix:my-module', '1.0.0')
+        overrides.put('netflix:my-module-2', '1.0.0')
         UpdateDependenciesValidator.validate(modules, overrides, true, false,
             extension.updateDependenciesFailOnInvalidCoordinates.get(),
             extension.updateDependenciesFailOnSimultaneousTaskUsage.get(),
@@ -138,7 +139,7 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
 
         then:
         def exception = thrown(DependencyLockException)
-        exception.message.contains("Please specify dependencies to update")
+        exception.message.contains('Please specify dependencies to update')
     }
 
     def 'should not fail when no modules to update and no overrides are passed in but disabled validation'() {
@@ -156,4 +157,5 @@ class UpdateDependenciesValidatorSpec extends FreshProjectSpec {
         then:
         notThrown(DependencyLockException)
     }
+
 }

--- a/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtensionPropertySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtensionPropertySpec.groovy
@@ -112,4 +112,116 @@ class DependencyResolutionVerifierExtensionPropertySpec extends BaseIntegrationT
         result.output.contains('isSetProperty: false')
     }
 
+    def 'shouldFailTheBuild getter returns Boolean not Property (backward compat)'() {
+        given:
+        buildFile << """
+            plugins { id 'com.netflix.nebula.dependency-lock' }
+            task checkType {
+                def ext = dependencyResolutionVerifierExtension
+                doLast {
+                    def value = ext.shouldFailTheBuild
+                    println "isBoolean: " + (value instanceof Boolean)
+                }
+            }
+        """
+        when:
+        def result = runTasks('checkType')
+        then:
+        result.output.contains('isBoolean: true')
+    }
+
+    def 'shouldFailTheBuild false assignment is respected (backward compat)'() {
+        given:
+        buildFile << """
+            plugins { id 'com.netflix.nebula.dependency-lock' }
+            dependencyResolutionVerifierExtension {
+                shouldFailTheBuild = false
+            }
+            task checkValue {
+                def ext = dependencyResolutionVerifierExtension
+                doLast {
+                    println "value: " + ext.shouldFailTheBuild
+                }
+            }
+        """
+        when:
+        def result = runTasks('checkValue')
+        then:
+        result.output.contains('value: false')
+    }
+
+    def 'enableLockFileValidation getter returns Boolean not Property (backward compat)'() {
+        given:
+        buildFile << """
+            plugins { id 'com.netflix.nebula.dependency-lock' }
+            task checkType {
+                def ext = dependencyResolutionVerifierExtension
+                doLast {
+                    def value = ext.enableLockFileValidation
+                    println "isBoolean: " + (value instanceof Boolean)
+                }
+            }
+        """
+        when:
+        def result = runTasks('checkType')
+        then:
+        result.output.contains('isBoolean: true')
+    }
+
+    def 'missingVersionsMessageAddition getter returns String not Property (backward compat)'() {
+        given:
+        buildFile << """
+            plugins { id 'com.netflix.nebula.dependency-lock' }
+            task checkType {
+                def ext = dependencyResolutionVerifierExtension
+                doLast {
+                    def value = ext.missingVersionsMessageAddition
+                    println "isString: " + (value instanceof String)
+                }
+            }
+        """
+        when:
+        def result = runTasks('checkType')
+        then:
+        result.output.contains('isString: true')
+    }
+
+    def 'missingVersionsMessageAddition assignment is reflected in getter (backward compat)'() {
+        given:
+        buildFile << """
+            plugins { id 'com.netflix.nebula.dependency-lock' }
+            dependencyResolutionVerifierExtension {
+                missingVersionsMessageAddition = 'See go/deps for help.'
+            }
+            task checkValue {
+                def ext = dependencyResolutionVerifierExtension
+                doLast {
+                    println "msg: " + ext.missingVersionsMessageAddition
+                }
+            }
+        """
+        when:
+        def result = runTasks('checkValue')
+        then:
+        result.output.contains('msg: See go/deps for help.')
+    }
+
+    def 'resolvedVersionDoesNotEqualLockedVersionMessageAddition getter returns String not Property (backward compat)'() {
+        given:
+        buildFile << """
+            plugins { id 'com.netflix.nebula.dependency-lock' }
+            task checkType {
+                def ext = dependencyResolutionVerifierExtension
+                doLast {
+                    def value = ext.resolvedVersionDoesNotEqualLockedVersionMessageAddition
+                    println "isString: " + (value instanceof String)
+                }
+            }
+        """
+        when:
+        def result = runTasks('checkType')
+        then:
+        result.output.contains('isString: true')
+    }
+
 }

--- a/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtensionPropertySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtensionPropertySpec.groovy
@@ -111,4 +111,5 @@ class DependencyResolutionVerifierExtensionPropertySpec extends BaseIntegrationT
         result.output.contains('isSet: true')
         result.output.contains('isSetProperty: false')
     }
+
 }

--- a/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtensionPropertySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtensionPropertySpec.groovy
@@ -1,0 +1,114 @@
+package nebula.plugin.dependencyverifier
+
+import nebula.plugin.BaseIntegrationTestKitSpec
+
+/**
+ * Validates that DependencyResolutionVerifierExtension SetProperty fields expose backward-compatible
+ * Set&lt;String&gt; getter/setter bridges so build scripts using Groovy = assignment continue to work.
+ */
+class DependencyResolutionVerifierExtensionPropertySpec extends BaseIntegrationTestKitSpec {
+
+    def 'configurationsToExclude supports Groovy = assignment (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            dependencyResolutionVerifierExtension {
+                configurationsToExclude = ['testRuntimeClasspath', 'testCompileClasspath'] as Set
+            }
+
+            task checkConfig {
+                def ext = dependencyResolutionVerifierExtension
+                doLast {
+                    println "excluded: " + ext.configurationsToExclude
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkConfig')
+
+        then:
+        result.output.contains('testRuntimeClasspath')
+        result.output.contains('testCompileClasspath')
+    }
+
+    def 'configurationsToExclude getter returns Set not SetProperty'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            task checkType {
+                def ext = dependencyResolutionVerifierExtension
+                doLast {
+                    def value = ext.configurationsToExclude
+                    println "isSet: " + (value instanceof Set)
+                    println "isSetProperty: " + value.getClass().name.contains('SetProperty')
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkType')
+
+        then:
+        result.output.contains('isSet: true')
+        result.output.contains('isSetProperty: false')
+    }
+
+    def 'tasksToExclude supports Groovy = assignment (backward compat)'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            dependencyResolutionVerifierExtension {
+                tasksToExclude = ['help', 'dependencies'] as Set
+            }
+
+            task checkConfig {
+                def ext = dependencyResolutionVerifierExtension
+                doLast {
+                    println "excluded: " + ext.tasksToExclude
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkConfig')
+
+        then:
+        result.output.contains('help')
+        result.output.contains('dependencies')
+    }
+
+    def 'tasksToExclude getter returns Set not SetProperty'() {
+        given:
+        buildFile << """
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            task checkType {
+                def ext = dependencyResolutionVerifierExtension
+                doLast {
+                    def value = ext.tasksToExclude
+                    println "isSet: " + (value instanceof Set)
+                    println "isSetProperty: " + value.getClass().name.contains('SetProperty')
+                }
+            }
+        """
+
+        when:
+        def result = runTasks('checkType')
+
+        then:
+        result.output.contains('isSet: true')
+        result.output.contains('isSetProperty: false')
+    }
+}

--- a/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtensionPropertySpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierExtensionPropertySpec.groovy
@@ -8,6 +8,33 @@ import nebula.plugin.BaseIntegrationTestKitSpec
  */
 class DependencyResolutionVerifierExtensionPropertySpec extends BaseIntegrationTestKitSpec {
 
+    def 'verifier extension properties use default conventions'() {
+        given:
+        buildFile << """
+            plugins { id 'com.netflix.nebula.dependency-lock' }
+            task checkDefaults {
+                def ext = dependencyResolutionVerifierExtension
+                doLast {
+                    println "shouldFailTheBuild: " + ext.shouldFailTheBuild
+                    println "configurationsToExclude: " + ext.configurationsToExclude
+                    println "missingVersionsMessageAddition: '" + ext.missingVersionsMessageAddition + "'"
+                    println "resolvedVersionMsg: '" + ext.resolvedVersionDoesNotEqualLockedVersionMessageAddition + "'"
+                    println "tasksToExclude: " + ext.tasksToExclude
+                    println "enableLockFileValidation: " + ext.enableLockFileValidation
+                }
+            }
+        """
+        when:
+        def result = runTasks('checkDefaults')
+        then:
+        result.output.contains('shouldFailTheBuild: true')
+        result.output.contains('configurationsToExclude: []')
+        result.output.contains("missingVersionsMessageAddition: ''")
+        result.output.contains("resolvedVersionMsg: ''")
+        result.output.contains('tasksToExclude: []')
+        result.output.contains('enableLockFileValidation: true')
+    }
+
     def 'configurationsToExclude supports Groovy = assignment (backward compat)'() {
         given:
         buildFile << """

--- a/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
+++ b/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
@@ -15,17 +15,7 @@
  *     limitations under the License.
  *
  */
-
 package nebula.plugin.dependencyverifier
-
-import nebula.plugin.BaseIntegrationTestKitSpec
-import nebula.plugin.VerifierOutputAssertionsBase
-import nebula.test.dependencies.DependencyGraphBuilder
-import nebula.test.dependencies.GradleDependencyGenerator
-import nebula.test.dependencies.ModuleBuilder
-import spock.lang.Ignore
-import spock.lang.Subject
-import spock.lang.Unroll
 
 import static nebula.plugin.VerifierOutputAssertionsBase.assertConfigurationCacheStateCouldNotBeStored
 import static nebula.plugin.VerifierOutputAssertionsBase.assertConfigurationCachingIsNotMentioned
@@ -40,1147 +30,16 @@ import static nebula.plugin.dependencyverifier.DependencyResolutionVerifierTest.
 import static nebula.plugin.dependencyverifier.DependencyResolutionVerifierTest.OutputAssertions.assertResolutionFailureMessage
 import static nebula.plugin.dependencyverifier.DependencyResolutionVerifierTest.OutputAssertions.dependencyProjectPair
 
-@Subject(DependencyResolutionVerifierKt)
-class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
-
-    def mavenrepo
-
-    def setup() {
-        def graph = new DependencyGraphBuilder()
-                .addModule('test.nebula:a:1.0.0')
-                .addModule('test.nebula:b:1.0.0')
-                .addModule('test.nebula:c:1.1.0')
-                .addModule(new ModuleBuilder('has.missing.transitive:a:1.0.0').addDependency('transitive.not.available:a:1.0.0').build())
-                .build()
-
-        mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen")
-        mavenrepo.generateTestMavenRepo()
-
-        def transitiveNotAvailableDep = new File(mavenrepo.getMavenRepoDir(), "transitive/not/available/a")
-        transitiveNotAvailableDep.deleteDir() // to create a missing transitive dependency
-    }
-
-    @Unroll
-    def 'no verification errors - #description'() {
-        given:
-        setupSingleProject()
-
-        when:
-        def results = runTasks(*tasks)
-
-        then:
-        !results.output.contains('FAILURE')
-        assertNoConfigurationCacheStoringIssues(results.output)
-
-        where:
-        tasks                                                   | description
-        ['dependencies', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
-    }
-
-    @Unroll
-    def 'error displayed when direct dependency is missing - #description'() {
-        given:
-        setupSingleProject()
-
-        buildFile << """
-            dependencies {
-                implementation 'not.available:a:1.0.0' // dependency is not found
-            }
-            """.stripIndent()
-
-        when:
-        def results = runTasksAndFail(*tasks)
-
-        then:
-        results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCacheStateCouldNotBeStored(results.output)
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForDependency(results.output, "not.available:a:1.0.0")
-
-        where:
-        tasks                                                                                | description
-        ['build']                                                                            | 'resolve dependencies naturally'
-        ['dependencies', '--configuration', 'compileClasspath', 'build', 'buildEnvironment'] | 'explicitly resolve as part of task chain'
-    }
-
-    def 'error displayed when direct dependency is missing - reporting task only'() {
-        given:
-        setupSingleProject()
-
-        buildFile << """
-            dependencies {
-                implementation 'not.available:a:1.0.0' // dependency is not found
-            }
-            """.stripIndent()
-
-        when:
-        def results = runTasksAndFail(*tasks)
-
-        then:
-        results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCachingIsNotMentioned(results.output)
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForDependency(results.output, "not.available:a:1.0.0")
-
-        where:
-        tasks                                                   | description
-        ['dependencies', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
-    }
-
-    @Unroll
-    def 'error displayed when transitive dependency is missing - #description'() {
-        given:
-        setupSingleProject()
-
-        buildFile << """
-            dependencies {
-                implementation 'has.missing.transitive:a:1.0.0' // transitive dependency is missing
-            }
-            """.stripIndent()
-
-        when:
-        def results = runTasksAndFail(*tasks)
-
-        then:
-        results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCacheStateCouldNotBeStored(results.output)
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForDependency(results.output, "transitive.not.available:a:1.0.0")
-
-        where:
-        tasks                                                                                | description
-        ['build']                                                                            | 'resolve dependencies naturally'
-        ['dependencies', '--configuration', 'compileClasspath', 'build', 'buildEnvironment'] | 'explicitly resolve as part of task chain'
-    }
-
-    def 'error displayed when transitive dependency is missing - reporting task only'() {
-        given:
-        setupSingleProject()
-
-        buildFile << """
-            dependencies {
-                implementation 'has.missing.transitive:a:1.0.0' // transitive dependency is missing
-            }
-            """.stripIndent()
-
-        when:
-        def results = runTasksAndFail(*tasks)
-
-        then:
-        results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCachingIsNotMentioned(results.output)
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForDependency(results.output, "transitive.not.available:a:1.0.0")
-
-        where:
-        tasks                                                   | description
-        ['dependencies', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
-    }
-
-    @Unroll
-    def 'error displayed when version is missing - #description'() {
-        given:
-        setupSingleProject()
-
-        buildFile << """
-            dependencies {
-                implementation 'test.nebula:c' // version is missing
-                implementation 'test.nebula:d' // version is missing
-            }
-            """.stripIndent()
-
-        when:
-        def results = runTasksAndFail(*tasks)
-
-        then:
-        results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCacheStateCouldNotBeStored(results.output)
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForMissingVersionDependencies(results.output, ["test.nebula:c", "test.nebula:d"])
-
-        where:
-        tasks                                                                                | description
-        ['build']                                                                            | 'resolve dependencies naturally'
-        ['dependencies', '--configuration', 'compileClasspath', 'build', 'buildEnvironment'] | 'explicitly resolve as part of task chain'
-    }
-
-    def 'error displayed when version is missing - reporting task only'() {
-        given:
-        setupSingleProject()
-
-        buildFile << """
-            dependencies {
-                implementation 'test.nebula:c' // version is missing
-                implementation 'test.nebula:d' // version is missing
-            }
-            """.stripIndent()
-
-        when:
-        def results = runTasksAndFail(*tasks)
-
-        then:
-        results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCachingIsNotMentioned(results.output)
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForMissingVersionDependencies(results.output, ["test.nebula:c", "test.nebula:d"])
-
-        where:
-        tasks                                                   | description
-        ['dependencies', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
-    }
-
-    @Unroll
-    def 'error displayed when a dependency is not found and needed at compilation - #description'() {
-        given:
-        setupSingleProject()
-        buildFile << """
-            dependencies {
-                implementation 'junit:junit:999.99.9' // version is invalid yet needed for compilation
-            }
-            """.stripIndent()
-        writeUnitTest() // valid version of the junit library is not in the dependency declaration
-
-        when:
-        def results = runTasksAndFail(*tasks)
-
-        then:
-        results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCacheStateCouldNotBeStored(results.output)
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForDependency(results.output, "junit:junit:999.99.9")
-
-        where:
-        tasks                                                                                | description
-        ['build']                                                                            | 'resolve dependencies naturally'
-        ['dependencies', '--configuration', 'compileClasspath', 'build', 'buildEnvironment'] | 'explicitly resolve as part of task chain'
-    }
-
-    def 'error displayed when a dependency is not found and needed at compilation - reporting task only'() {
-        given:
-        setupSingleProject()
-        buildFile << """
-            dependencies {
-                implementation 'junit:junit:999.99.9' // version is invalid yet needed for compilation
-            }
-            """.stripIndent()
-        writeUnitTest() // valid version of the junit library is not in the dependency declaration
-
-        when:
-        def results = runTasksAndFail(*tasks)
-
-        then:
-        results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCachingIsNotMentioned(results.output)
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForDependency(results.output, "junit:junit:999.99.9")
-
-        where:
-        tasks                                                   | description
-        ['dependencies', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
-    }
-
-    @Unroll
-    def 'multiproject: missing direct dependencies - #description'() {
-        given:
-        setupMultiProject()
-
-        new File(projectDir, 'sub1/build.gradle') << """ \
-        dependencies {
-            implementation 'not.available:apricot:1.0.0' // dependency is not found
-        }
-        """.stripIndent()
-
-        new File(projectDir, 'sub2/build.gradle') << """ \
-        dependencies {
-            implementation 'not.available:banana-leaf:2.0.0' // dependency is not found
-        }
-        """.stripIndent()
-
-        when:
-        def results = runTasksAndFail(*tasks)
-
-        then:
-        results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCacheStateCouldNotBeStored(results.output)
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForDependencyForProject(results.output, "not.available:apricot:1.0.0", "sub1")
-
-        where:
-        tasks                                                                                      | description
-        ['build']                                                                                  | 'resolve dependencies naturally'
-        ['dependenciesForAll', '--configuration', 'compileClasspath', 'build', 'buildEnvironment'] | 'explicitly resolve as part of task chain'
-    }
-
-    def 'multiproject: missing direct dependencies - reporting task only'() {
-        given:
-        setupMultiProject()
-
-        new File(projectDir, 'sub1/build.gradle') << """ \
-        dependencies {
-            implementation 'not.available:apricot:1.0.0' // dependency is not found
-        }
-        """.stripIndent()
-
-        new File(projectDir, 'sub2/build.gradle') << """ \
-        dependencies {
-            implementation 'not.available:banana-leaf:2.0.0' // dependency is not found
-        }
-        """.stripIndent()
-
-        when:
-        def results = runTasksAndFail(*tasks)
-
-        then:
-        results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCachingIsNotMentioned(results.output)
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForDependencyForProject(results.output, "not.available:apricot:1.0.0", "sub1")
-
-        where:
-        tasks                                                         | description
-        ['dependenciesForAll', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
-    }
-
-    @Unroll
-    def 'multiproject: handles worker threads from spotbugs - #description'() {
-        given:
-        buildFile << """
-            buildscript {
-                repositories { maven { url = "https://plugins.gradle.org/m2/" } }
-                dependencies {
-                     classpath "com.github.spotbugs:com.github.spotbugs.gradle.plugin:6.4.8"
-                }
-            }            
-            """.stripIndent()
-        setupMultiProject()
-        buildFile << """
-            subprojects {
-                apply plugin: "com.github.spotbugs"
-                repositories {
-                    mavenCentral()
-                }
-                configurations.named('spotbugs').configure {
-                  resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-                       if (details.requested.group == 'org.ow2.asm') {
-                            details.useVersion '9.9'
-                            details.because "Asm 9.9 is required for JDK 25 support"
-                      }
-                  }
-                }
-            }
-            """.stripIndent()
-
-        new File(projectDir, 'sub1/build.gradle') << """ \
-            dependencies {
-                testImplementation 'junit:junit:4.12'
-            }
-            """.stripIndent()
-
-        new File(projectDir, 'sub2/build.gradle') << """ \
-            dependencies {
-                testImplementation 'junit:junit:4.12'
-            }
-            """.stripIndent()
-
-        when:
-        def results = runTasks(*tasks, '--warning-mode', 'all')
-
-        then:
-        !results.output.contains('FAILURE')
-        assertNoConfigurationCacheStoringIssues(results.output)
-        !results.output.contains('was resolved without accessing the project in a safe manner')
-
-        where:
-        tasks                                                         | description
-        ['spotbugsMain']                                              | 'calling spotbugsMain'
-        ['build']                                                     | 'resolve dependencies naturally'
-    }
-
-    def 'multiproject: handles worker threads from spotbugs - reporting task only'() {
-        given:
-        buildFile << """
-            buildscript {
-                repositories { maven { url = "https://plugins.gradle.org/m2/" } }
-                dependencies {
-                     classpath "com.github.spotbugs:com.github.spotbugs.gradle.plugin:6.4.8"
-                }
-            }            
-            """.stripIndent()
-        setupMultiProject()
-        buildFile << """
-            subprojects {
-                apply plugin: "com.github.spotbugs"
-                repositories {
-                    mavenCentral()
-                }
-                configurations.named('spotbugs').configure {
-                  resolutionStrategy.eachDependency { DependencyResolveDetails details ->
-                       if (details.requested.group == 'org.ow2.asm') {
-                            details.useVersion '9.9'
-                            details.because "Asm 9.9 is required for JDK 25 support"
-                      }
-                  }
-                }
-            }
-            """.stripIndent()
-
-        new File(projectDir, 'sub1/build.gradle') << """ \
-            dependencies {
-                testImplementation 'junit:junit:4.12'
-            }
-            """.stripIndent()
-
-        new File(projectDir, 'sub2/build.gradle') << """ \
-            dependencies {
-                testImplementation 'junit:junit:4.12'
-            }
-            """.stripIndent()
-
-        when:
-        def results = runTasks(*tasks, '--warning-mode', 'all')
-
-        then:
-        !results.output.contains('FAILURE')
-        assertNoConfigurationCacheStoringIssues(results.output)
-        !results.output.contains('was resolved without accessing the project in a safe manner')
-
-        where:
-        tasks | description
-        ['dependenciesForAll', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
-    }
-
-    @Unroll
-    def 'multiproject: works for parallel builds - #description'() {
-        given:
-        setupMultiProject()
-
-        new File(projectDir, 'sub1/build.gradle') << """ \
-        dependencies {
-            implementation 'not.available:apricot:1.0.0' // dependency is not found
-        }
-        """.stripIndent()
-
-        new File(projectDir, 'sub2/build.gradle') << """ \
-        dependencies {
-            implementation 'not.available:banana-leaf:2.0.0' // dependency is not found
-        }
-        """.stripIndent()
-
-        when:
-        def results = runTasksAndFail(*tasks, '--parallel')
-
-        then:
-        results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCacheStateCouldNotBeStored(results.output)
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForOneOfTheseDependencies(results.output, [
-                dependencyProjectPair("not.available:apricot:1.0.0", "sub1"),
-                dependencyProjectPair("not.available:banana-leaf:2.0.0", "sub2")
-        ])
-
-        where:
-        tasks                                                                                      | description
-        ['build']                                                                                  | 'resolve dependencies naturally'
-        ['dependenciesForAll', '--configuration', 'compileClasspath', 'build', 'buildEnvironment'] | 'explicitly resolve as part of task chain'
-    }
-
-    def 'multiproject: works for parallel builds - reporting task only'() {
-        given:
-        setupMultiProject()
-
-        new File(projectDir, 'sub1/build.gradle') << """ \
-        dependencies {
-            implementation 'not.available:apricot:1.0.0' // dependency is not found
-        }
-        """.stripIndent()
-
-        new File(projectDir, 'sub2/build.gradle') << """ \
-        dependencies {
-            implementation 'not.available:banana-leaf:2.0.0' // dependency is not found
-        }
-        """.stripIndent()
-
-        when:
-        def results = runTasksAndFail(*tasks, '--parallel')
-
-        then:
-        results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCachingIsNotMentioned(results.output)
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForOneOfTheseDependencies(results.output, [
-                dependencyProjectPair("not.available:apricot:1.0.0", "sub1"),
-                dependencyProjectPair("not.available:banana-leaf:2.0.0", "sub2")
-        ])
-
-        where:
-        tasks                                                         | description
-        ['dependenciesForAll', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
-    }
-
-    @Unroll
-    def 'missing a dependency declaration is not caught - #description'() {
-        given:
-        setupSingleProject()
-        writeUnitTest() // junit library is not in the dependency declaration
-
-        when:
-        def results = runTasksAndFail(*tasks)
-
-        then:
-        results.output.contains('FAILURE')
-        assertNoResolutionFailureMessage(results.output)
-
-        where:
-        tasks                                                                                | description
-        ['build']                                                                            | 'resolve dependencies naturally'
-        ['dependencies', '--configuration', 'compileClasspath', 'build', 'buildEnvironment'] | 'explicitly resolve as part of task chain'
-    }
-
-    @Unroll
-    def 'missing a dependency declaration is not caught - reporting task only'() {
-        given:
-        setupSingleProject()
-        writeUnitTest() // junit library is not in the dependency declaration
-
-        when:
-        def results = runTasks(*tasks)
-
-        then:
-        !results.output.contains('FAILURE')
-        assertNoConfigurationCacheStoringIssues(results.output)
-        assertNoResolutionFailureMessage(results.output)
-
-        where:
-        tasks                                                   | description
-        ['dependencies', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
-    }
-
-    @Unroll
-    def 'specify configurations to ignore via property via #setupStyle'() {
-        given:
-        setupSingleProject()
-
-        if (setupStyle == 'properties file') {
-            def file = new File("${projectDir}/gradle.properties")
-            file << """
-                dependencyResolutionVerifier.configurationsToExclude=specialConfig,otherSpecialConfig
-                """.stripIndent()
-        }
-
-        buildFile << """
-            configurations {
-                specialConfig
-                otherSpecialConfig
-            }
-            dependencies {
-                specialConfig 'not.available:apricot:1.0.0' // not available
-                otherSpecialConfig 'not.available:banana-leaf:2.0.0' // not available
-            }
-            """.stripIndent()
-
-        when:
-        def tasks = ['dependencies', '--configuration', 'compileClasspath']
-        if (setupStyle == 'command line') {
-            tasks += '-PdependencyResolutionVerifier.configurationsToExclude=specialConfig,otherSpecialConfig'
-        }
-        def results = runTasks(*tasks)
-
-        then:
-        assertNoResolutionFailureMessage(results.output)
-
-        where:
-        setupStyle << ['command line', 'properties file']
-    }
-
-    @Unroll
-    def 'displays error once with finalizers - #tasks'() {
-        given:
-        setupSingleProject()
-
-        buildFile << """
-            dependencies {
-                implementation 'not.available:a'
-            }
-            task myFinalizingTask {
-                println "Here's a great finalizing message"
-            }
-            task goodbye {
-                println "Goodbye!"
-            }
-            project.tasks.configureEach { Task task ->
-                if (task.name != 'myFinalizingTask' && task.name != 'clean') {
-                    task.finalizedBy project.tasks.named('myFinalizingTask')
-                }
-                if (task.name != 'myFinalizingTask' && task.name != 'goodbye' && task.name != 'clean') {
-                    task.finalizedBy project.tasks.named('goodbye')
-                }
-            }
-            """.stripIndent()
-
-        when:
-        def results = runTasksAndFail(*tasks)
-
-        then:
-        results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCacheStateCouldNotBeStored(results.output)
-        assertResolutionFailureMessage(results.output)
-        assertFailureMessageIsDisplayedOnce(results.output, "not.available:a")
-
-        where:
-        tasks << [['build'], ['build', '--parallel']]
-    }
-
-    @Unroll
-    def 'handles task configuration issue due to #failureType'() {
-        given:
-        setupSingleProject()
-        setupTaskThatRequiresResolvedConfiguration(buildFile)
-
-        buildFile << """
-            dependencies {
-                implementation '$dependency'
-            }
-            """.stripIndent()
-
-        when:
-        def results = runTasksAndFail('build')
-
-        then:
-        assert results.output.contains('FAILURE')
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForDependency(results.output, actualMissingDep ?: dependency)
-
-        where:
-        failureType                | dependency                       | actualMissingDep
-        'missing version'          | 'not.available:a'                | null
-        'direct dep not found'     | 'not.available:a:1.0.0'          | null
-        'transitive dep not found' | 'has.missing.transitive:a:1.0.0' | 'transitive.not.available:a:1.0.0'
-    }
-
-    @Unroll
-    def 'handles task configuration issue due to #failureType - multiproject'() {
-        given:
-        setupMultiProject()
-
-        def sub1BuildFile = new File(projectDir, 'sub1/build.gradle')
-        def sub2BuildFile = new File(projectDir, 'sub2/build.gradle')
-
-        setupTaskThatRequiresResolvedConfiguration(sub1BuildFile)
-        setupTaskThatRequiresResolvedConfiguration(sub2BuildFile)
-
-        sub1BuildFile << """ \
-        dependencies {
-            implementation '$dependency'
-        }
-        """.stripIndent()
-
-        def sub2Dependency = dependency.replace(':a', ':b')
-        sub2BuildFile << """
-        dependencies {
-            implementation '$sub2Dependency'
-        }
-        """.stripIndent()
-
-        when:
-        def results = runTasksAndFail('build')
-
-        then:
-        assert results.output.contains('FAILURE')
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForDependencyForProject(results.output, actualMissingDep ?: dependency, "sub1")
-        assert !results.output.contains("for project 'sub2'")
-
-        where:
-        failureType                | dependency                       | actualMissingDep
-        'missing version'          | 'not.available:a'                | null
-        'direct dep not found'     | 'not.available:a:1.0.0'          | null
-        'transitive dep not found' | 'has.missing.transitive:a:1.0.0' | 'transitive.not.available:a:1.0.0'
-    }
-
-    @Unroll
-    def 'handles task configuration issue due to #failureType - multiproject and parallel'() {
-        given:
-        setupMultiProject()
-
-        def sub1BuildFile = new File(projectDir, 'sub1/build.gradle')
-        def sub2BuildFile = new File(projectDir, 'sub2/build.gradle')
-
-        setupTaskThatRequiresResolvedConfiguration(sub1BuildFile)
-        setupTaskThatRequiresResolvedConfiguration(sub2BuildFile)
-
-        sub1BuildFile << """
-        dependencies {
-            implementation '$dependency'
-        }
-        """.stripIndent()
-
-        def sub2Dependency = dependency.replace(':a', ':b')
-        sub2BuildFile << """
-        dependencies {
-            implementation '$sub2Dependency'
-        }
-        """.stripIndent()
-
-        when:
-        def results = runTasksAndFail('build')
-
-        then:
-        assert results.output.contains('FAILURE')
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForDependencyForProject(results.output, actualMissingDep ?: dependency, "sub1")
-        assert !results.output.contains("for project 'sub2'")
-
-        where:
-        failureType                | dependency                       | actualMissingDep
-        'missing version'          | 'not.available:a'                | null
-        'direct dep not found'     | 'not.available:a:1.0.0'          | null
-        'transitive dep not found' | 'has.missing.transitive:a:1.0.0' | 'transitive.not.available:a:1.0.0'
-    }
-
-    @Unroll
-    def 'uses extension for #description'() {
-        given:
-        setupSingleProject()
-
-        def configurationName = description == 'configurationsToExclude'
-                ? 'myConfig' : 'implementation'
-
-        buildFile << """
-            configurations { myConfig }
-            dependencies {
-                $configurationName 'not.available:a'
-            }
             import nebula.plugin.dependencyverifier.DependencyResolutionVerifierExtension
-            plugins.withId('com.netflix.nebula.dependency-lock') {
-                def extension = extensions.getByType(DependencyResolutionVerifierExtension.class)
-                def list = new ArrayList<>()
-                $extensionSetting
-            }
-            """.stripIndent()
-
-        when:
-        def results
-        if (willFail) {
-            results = runTasksAndFail('dependencies')
-        } else {
-            results = runTasks('dependencies')
-        }
-
-        then:
-        if (seeErrors) {
-            assertResolutionFailureMessage(results.output)
-            assertResolutionFailureForDependency(results.output, "not.available:a")
-            if (description == 'missingVersionsMessageAddition') {
-                assert results.output.contains('You can find additional help at...'),
-                        "Expected output to contain missingVersionsMessageAddition: 'You can find additional help at...'"
-            }
-        } else {
-            assertNoResolutionFailureMessage(results.output)
-        }
-
-        where:
-        extensionSetting                                                                  | description                      | willFail | seeErrors
-        'extension.missingVersionsMessageAddition = "You can find additional help at..."' | 'missingVersionsMessageAddition' | true     | true
-        'extension.shouldFailTheBuild = false'                                            | 'shouldFailTheBuild'             | false    | true
-        "list.addAll('myConfig')\n\textension.configurationsToExclude = list"             | 'configurationsToExclude'        | false    | false
-        "list.addAll('dependencies')\n\textension.tasksToExclude = list"                  | 'tasksToExclude'                 | false    | false
-    }
-
-    def 'unresolved dependencies output includes missingVersionsMessageAddition when some dependencies lack a version'() {
-        given:
-        setupSingleProject()
-        def customAddition = 'Custom help: http://example.com/dependency-help'
-        buildFile << """
-            dependencies {
-                implementation 'not.available:a'
-            }
-            dependencyResolutionVerifierExtension {
-                missingVersionsMessageAddition = '$customAddition'
-            }
-        """.stripIndent()
-
-        when:
-        def results = runTasksAndFail('dependencies')
-
-        then:
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForDependency(results.output, 'not.available:a')
-        assert results.output.contains(customAddition),
-                "Expected output to contain missingVersionsMessageAddition: ${customAddition}"
-    }
-
-    def 'verifier skips configurations in the skip list (e.g. configurationsToExclude)'() {
-        given:
-        setupSingleProject()
-        new File(projectDir, 'gradle.properties') << """
-            dependencyResolutionVerifier.configurationsToExclude=skipMe
-        """.stripIndent()
-        buildFile << """
-            configurations {
-                skipMe {
-                    canBeResolved = true
-                }
-            }
-            dependencies {
-                skipMe 'not.available:unresolvable:1.0.0'
-            }
-        """.stripIndent()
-
-        when:
-        def results = runTasks('dependencies', '--configuration', 'compileClasspath')
-
-        then:
-        assert !results.output.toString().contains('FAILURE'):
-                "Verifier should skip skipMe via configurationsToExclude; without skip we would resolve it and fail"
-        assertNoConfigurationCacheStoringIssues(results.output)
-    }
-
-    def 'strict platform constraint aligns versions and verifier does not fail on non-selected versions'() {
-        given:
-        setupSingleProject()
-        buildFile << """
-            repositories {
-                mavenCentral()
-            }
-            dependencies {
-                implementation 'org.springframework:spring-core:5.2.9.RELEASE'
-                implementation 'org.springframework:spring-core:5.2.12.RELEASE'
-                implementation platform('org.springframework:spring-framework-bom:5.2.14.RELEASE')
-                implementation 'org.springframework:spring-context'
-            }
-        """.stripIndent()
-
-        when:
-        def results = runTasks('dependencies', '--configuration', 'runtimeClasspath')
-
-        then: 'we do not see failures'
-        !results.output.contains('FAILURE')
-        !results.output.contains('verifyDependencyResolution FAILED')
-        !results.output.contains('Failed to resolve the following dependencies:')
-
-        and: 'we see conflict-resolved versions resolve to a single version'
-        results.output.contains('org.springframework:spring-core:5.2.9.RELEASE -> 5.2.14.RELEASE')
-        results.output.contains('org.springframework:spring-core:5.2.12.RELEASE -> 5.2.14.RELEASE')
-        results.output.contains('org.springframework:spring-core:5.2.14.RELEASE')
-
-        and: 'we do not see resolved final path at lower non-selected versions'
-        !results.output.contains('org.springframework:spring-core:5.2.9.RELEASE\n')
-        !results.output.contains('org.springframework:spring-core:5.2.12.RELEASE\n')
-
-        and: 'we see version provided by BOM successfully'
-        results.output.contains('org.springframework:spring-context -> 5.2.14.RELEASE\n')
-
-        and: 'we do not see issues about dependencies missing a version, which would be provided by the BOM'
-        !results.output.contains('The following dependencies are missing a version:')
-    }
-
-    def 'handles root and subproject of the same name'() {
-        given:
-        setupMultiProject()
-
-        def sub1BuildFile = new File(projectDir, 'sub1/build.gradle')
-        sub1BuildFile << """
-        dependencies {
-            implementation 'not.available:a:1.0.0' // dependency is not found
-        }
-        """.stripIndent()
-
-        settingsFile.createNewFile()
-        settingsFile.text = """
-            rootProject.name='sub1'
-            include "sub1"
-            include "sub2"
-            """.stripIndent()
-
-        when:
-        def results = runTasksAndFail('build')
-
-        then:
-        results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCacheStateCouldNotBeStored(results.output)
-        assertResolutionFailureMessage(results.output)
-        assertFailureMessageIsDisplayedOnce(results.output, "not.available:a:1.0.0")
-        assertResolutionFailureForDependencyForProject(results.output, "not.available:a:1.0.0", "sub1")
-    }
-
-    def 'handles build failure from task configuration issue'() {
-        given:
-        setupSingleProject()
-        buildFile << """
-            dependencies {
-                implementation 'not.available:a:1.0.0' // dependency is not found
-            }
-            task goodbye {
-                println "Goodbye!"
-            }
-            build.finalizedBy project.tasks.named('goodbye') onlyIf {
-                project.configurations.compileClasspath.resolvedConfiguration.resolvedArtifacts.collect {it.name}.contains('bananan')
-            }
-            """.stripIndent()
-
-        when:
-        def results = runTasksAndFail('build')
-
-        then:
-        results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCacheStateCouldNotBeStored(results.output)
-        assertResolutionFailureMessage(results.output)
-        assertFailureMessageIsDisplayedOnce(results.output, "not.available:a:1.0.0")
-        assertResolutionFailureForDependency(results.output, "not.available:a:1.0.0")
-    }
-
-    def 'handles task that requires resolved configuration with no issues'() {
-        given:
-        setupSingleProject()
-
-        buildFile << """
-            ${taskThatRequiresConfigurationDependencies()}
-            """.stripIndent()
-
-        when:
-        def results = runTasks('build')
-
-        then:
-        assert !results.output.contains('FAILURE')
-        assertNoConfigurationCacheStoringIssues(results.output)
-    }
-
-    @Unroll
-    def 'handles task that requires resolved configuration with an issue due to #failureType'() {
-        given:
-        setupSingleProject()
-
-        buildFile << """
-            dependencies {
-                implementation '$dependency'
-            }
-            ${taskThatRequiresConfigurationDependencies()}
-            """.stripIndent()
-
-        when:
-        def results = runTasksAndFail('build')
-
-        then:
-        assert results.output.contains('FAILURE')
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForDependency(results.output, actualMissingDep ?: dependency)
-
-        where:
-        failureType                | dependency                       | actualMissingDep
-        'missing version'          | 'not.available:a'                | null
-        'direct dep not found'     | 'not.available:a:1.0.0'          | null
-        'transitive dep not found' | 'has.missing.transitive:a:1.0.0' | 'transitive.not.available:a:1.0.0'
-    }
-
-    @Unroll
-    def 'handles task that requires resolved configuration with an issue due to #failureType - multiproject'() {
-        given:
-        setupMultiProject()
-
-        def sub1BuildFile = new File(projectDir, 'sub1/build.gradle')
-        def sub2BuildFile = new File(projectDir, 'sub2/build.gradle')
-
-        sub1BuildFile << """ \
-        dependencies {
-            implementation '$dependency'
-        }
-        ${taskThatRequiresConfigurationDependencies()}
-        """.stripIndent()
-
-        def sub2Dependency = dependency.replace(':a', ':b')
-        sub2BuildFile << """
-        dependencies {
-            implementation '$sub2Dependency'
-        }
-        ${taskThatRequiresConfigurationDependencies()}
-        """.stripIndent()
-
-        when:
-        def results = runTasksAndFail('build')
-
-        then:
-        assert results.output.contains('FAILURE')
-        assertExecutionFailedForTask(results.output)
-        assertConfigurationCacheStateCouldNotBeStored(results.output)
-        assertResolutionFailureForDependencyForProject(results.output, actualMissingDep ?: dependency, "sub1")
-        assert !results.output.contains("for project 'sub2'")
-
-        where:
-        failureType                | dependency                       | actualMissingDep
-        'missing version'          | 'not.available:a'                | null
-        'direct dep not found'     | 'not.available:a:1.0.0'          | null
-        'transitive dep not found' | 'has.missing.transitive:a:1.0.0' | 'transitive.not.available:a:1.0.0'
-    }
-
-    @Unroll
-    def 'handles task that requires resolved configuration with an issue due to #failureType - multiproject and parallel'() {
-        given:
-        setupMultiProject()
-
-        def sub1BuildFile = new File(projectDir, 'sub1/build.gradle')
-        def sub2BuildFile = new File(projectDir, 'sub2/build.gradle')
-
-        sub1BuildFile << """
-        dependencies {
-            implementation '$dependency'
-        }
-        ${taskThatRequiresConfigurationDependencies()}
-        """.stripIndent()
-
-        def sub2Dependency = dependency.replace(':a', ':b')
-        sub2BuildFile << """
-        dependencies {
-            implementation '$sub2Dependency'
-        }
-        ${taskThatRequiresConfigurationDependencies()}
-        """.stripIndent()
-
-        when:
-        def results = runTasksAndFail('build')
-
-        then:
-        assert results.output.contains('FAILURE')
-        assertResolutionFailureMessage(results.output)
-        assertResolutionFailureForDependencyForProject(results.output, actualMissingDep ?: dependency, "sub1")
-        assert !results.output.contains("for project 'sub2'")
-
-        where:
-        failureType                | dependency                       | actualMissingDep
-        'missing version'          | 'not.available:a'                | null
-        'direct dep not found'     | 'not.available:a:1.0.0'          | null
-        'transitive dep not found' | 'has.missing.transitive:a:1.0.0' | 'transitive.not.available:a:1.0.0'
-    }
-
-    @Unroll
-    def 'resolved versions are not equal to locked versions because locked versions are not aligned - core alignment #coreAlignment - core locking #coreLocking'() {
-        given:
-        setupSingleProjectWithLockedVersionsThatAreNotAligned()
-
-        when:
-        def flags = ["-Dnebula.features.coreAlignmentSupport=${coreAlignment}", "-Dnebula.features.coreLockingSupport=${coreLocking}"]
-        def insightResults = runTasksAndFail('dependencyInsight', '--dependency', 'test.nebula', *flags)
-        def results = runTasksAndFail('dependencies', '--configuration', 'compileClasspath', *flags)
-
-        then:
-        insightResults.output.contains('test.nebula:a:1.1.0 -> 1.2.0\n')
-        insightResults.output.contains('test.nebula:b:1.2.0\n')
-        insightResults.output.contains('test.nebula:c:1.1.0 -> 1.2.0\n')
-
-        insightResults.output.contains('FAILED')
-
-        insightResults.output.contains("Dependency lock state is out of date:")
-        insightResults.output.contains("Resolved 'test.nebula:a:1.2.0' instead of locked version '1.1.0' for project")
-        insightResults.output.contains("Resolved 'test.nebula:c:1.2.0' instead of locked version '1.1.0' for project")
-        insightResults.output.contains("Resolved 'test.nebula:d:1.2.0' instead of locked version '1.1.0' for project")
-        insightResults.output.contains('Please update your dependency locks or your build file constraints.')
-
-        results.output.contains('FAILED')
-
-        results.output.contains("Dependency lock state is out of date:")
-        results.output.contains("Resolved 'test.nebula:a:1.2.0' instead of locked version '1.1.0' for project")
-        results.output.contains("Resolved 'test.nebula:c:1.2.0' instead of locked version '1.1.0' for project")
-        results.output.contains("Resolved 'test.nebula:d:1.2.0' instead of locked version '1.1.0' for project")
-        results.output.contains('Please update your dependency locks or your build file constraints.')
-
-        where:
-        coreAlignment | coreLocking
-        true          | false
-    }
-
-    @Unroll
-    def 'resolved versions are not equal to locked versions - handles unlocked transitives - core alignment #coreAlignment - core locking #coreLocking'() {
-        given:
-        setupSingleProjectWithLockedVersionsThatAreNotAligned()
-
-        when:
-        def flags = ["-Dnebula.features.coreAlignmentSupport=${coreAlignment}", "-Dnebula.features.coreLockingSupport=${coreLocking}"]
-        runTasks('generateLock', 'saveLock', *flags) // without locking transitives
-        def results = runTasks('dependencies', '--configuration', 'compileClasspath', *flags)
-
-        then:
-        results.output.contains('SUCCESS')
-
-        where:
-        coreAlignment | coreLocking
-        true          | false
-    }
-
-    @Unroll
-    def 'resolved versions are not equal to locked versions with override file - core alignment #coreAlignment - core locking #coreLocking'() {
-        given:
-        setupSingleProjectWithLockedVersionsThatAreNotAligned()
-
-        def graph = new DependencyGraphBuilder()
-                .addModule(new ModuleBuilder('test.nebula:a:1.3.0').addDependency('test.nebula:d:1.3.0').build())
-                .addModule('test.nebula:b:1.3.0')
-                .addModule('test.nebula:c:1.3.0')
-                .build()
-        def updatedmavenrepo = new GradleDependencyGenerator(graph, "$projectDir/testrepogen")
-        updatedmavenrepo.generateTestMavenRepo()
-
-        def dependenciesLockOverride = new File(projectDir, 'override.lock')
-        dependenciesLockOverride << '''
-            { "test.nebula:a": "1.3.0" }
-            '''.stripIndent()
-
-        when:
-        def flags = ['-PdependencyLock.overrideFile=override.lock', "-Dnebula.features.coreAlignmentSupport=${coreAlignment}", "-Dnebula.features.coreLockingSupport=${coreLocking}"]
-        def insightResults = runTasksAndFail('dependencyInsight', '--dependency', 'test.nebula', *flags)
-        def results = runTasksAndFail('dependencies', '--configuration', 'compileClasspath', *flags)
-
-        then:
-        insightResults.output.contains('using override file: override.lock')
-
-        insightResults.output.contains('test.nebula:a:1.1.0 -> 1.3.0\n')
-        insightResults.output.contains('test.nebula:b:1.3.0\n')
-        insightResults.output.contains('test.nebula:c:1.1.0 -> 1.3.0\n')
-        insightResults.output.contains('test.nebula:d:1.3.0\n')
-
-        insightResults.output.contains('FAILED')
-
-        insightResults.output.contains("Dependency lock state is out of date:")
-        !insightResults.output.contains("Resolved 'test.nebula:a:1.3.0' instead of locked version")
-        insightResults.output.contains("Resolved 'test.nebula:b:1.3.0' instead of locked version '1.2.0' for project")
-        insightResults.output.contains("Resolved 'test.nebula:c:1.3.0' instead of locked version '1.1.0' for project")
-        insightResults.output.contains("Resolved 'test.nebula:d:1.3.0' instead of locked version '1.1.0' for project")
-        insightResults.output.contains('Please update your dependency locks or your build file constraints.')
-
-        results.output.contains('FAILED')
-
-        results.output.contains("Dependency lock state is out of date:")
-        !results.output.contains("Resolved 'test.nebula:a:1.3.0' instead of locked version")
-        results.output.contains("Resolved 'test.nebula:b:1.3.0' instead of locked version '1.2.0' for project")
-        results.output.contains("Resolved 'test.nebula:c:1.3.0' instead of locked version '1.1.0' for project")
-        results.output.contains("Resolved 'test.nebula:d:1.3.0' instead of locked version '1.1.0' for project")
-        results.output.contains('Please update your dependency locks or your build file constraints.')
-
-        where:
-        coreAlignment | coreLocking
-        true          | false
-    }
-
-    @Unroll
-    def 'resolved versions are not equal to locked versions - can configure extension messaging - core alignment #coreAlignment - core locking #coreLocking'() {
-        given:
-        setupSingleProjectWithLockedVersionsThatAreNotAligned()
-        def extensionMessage = 'You may see this after changing from Nebula alignment to core Gradle alignment for the first time in this repository'
-        buildFile << """
             import nebula.plugin.dependencyverifier.DependencyResolutionVerifierExtension
+import nebula.plugin.BaseIntegrationTestKitSpec
+import nebula.plugin.VerifierOutputAssertionsBase
+import nebula.test.dependencies.DependencyGraphBuilder
+import nebula.test.dependencies.GradleDependencyGenerator
+import nebula.test.dependencies.ModuleBuilder
+import spock.lang.Ignore
+import spock.lang.Subject
+import spock.lang.Unroll
             plugins.withId('com.netflix.nebula.dependency-lock') {
                 def extension = extensions.getByType(DependencyResolutionVerifierExtension.class)
                 extension.resolvedVersionDoesNotEqualLockedVersionMessageAddition = '$extensionMessage'
@@ -1212,7 +71,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILED')
 
-        results.output.contains("Dependency lock state is out of date:")
+        results.output.contains('Dependency lock state is out of date:')
         results.output.contains("Resolved 'test.nebula:a:1.2.0' instead of locked version '1.1.0' for project 'sub1'")
         results.output.contains("Resolved 'test.nebula:c:1.2.0' instead of locked version '1.1.0' for project 'sub1'")
         results.output.contains("Resolved 'test.nebula:d:1.2.0' instead of locked version '1.1.0' for project 'sub1'")
@@ -1235,7 +94,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         then:
         results.output.contains('FAILED')
 
-        results.output.contains("Dependency lock state is out of date:")
+        results.output.contains('Dependency lock state is out of date:')
 
         results.output.contains("Resolved 'test.nebula:a:1.2.0' instead of locked version '1.1.0' for project 'sub1'")
         results.output.contains("Resolved 'test.nebula:c:1.2.0' instead of locked version '1.1.0' for project 'sub1'")
@@ -1324,13 +183,13 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         new File(projectDir, 'global.lock').text = globalLockText
 
         when:
-        def flags = ["-Dnebula.features.coreAlignmentSupport=true", "-Dnebula.features.coreLockingSupport=false"]
+        def flags = ['-Dnebula.features.coreAlignmentSupport=true', '-Dnebula.features.coreLockingSupport=false']
         def results = runTasksAndFail('dependenciesForAll', '--configuration', 'compileClasspath', *flags)
 
         then:
         results.output.contains('FAILED')
 
-        results.output.contains("Dependency lock state is out of date:")
+        results.output.contains('Dependency lock state is out of date:')
 
         results.output.contains("Resolved 'test.nebula:a:1.2.0' instead of locked version '1.1.0' for project 'sub1'")
         results.output.contains("Resolved 'test.nebula:c:1.2.0' instead of locked version '1.1.0' for project 'sub1'")
@@ -1461,9 +320,9 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
                 }
                 """.stripIndent()
 
-        def sub1Dir = new File(projectDir, "included-project/sub1")
+        def sub1Dir = new File(projectDir, 'included-project/sub1')
         sub1Dir.mkdirs()
-        def sub1BuildFile = new File(sub1Dir, "build.gradle")
+        def sub1BuildFile = new File(sub1Dir, 'build.gradle')
         sub1BuildFile << """
                 dependencies {
                     implementation 'not.available:b:1.0.0' // dependency is not found either
@@ -1475,7 +334,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
 
         then:
         assert results.output.contains('> Task :included-project:sub1:dependencies')
-        assertResolutionFailureForDependencyForProject(results.output, "not.available:b:1.0.0", "sub1")
+        assertResolutionFailureForDependencyForProject(results.output, 'not.available:b:1.0.0', 'sub1')
         assert results.output.contains('FAIL')
     }
 
@@ -1498,7 +357,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
             !noIssuesResult.output.contains('FAILURE')
             !noIssuesResult.output.contains('verifyDependencyResolution FAILED')
 
-            !noIssuesResult.output.contains("Failed to resolve")
+            !noIssuesResult.output.contains('Failed to resolve')
         }
 
         and: 'in particular, the synthetic {strictly 2.0.0} constraint is not falsely reported as unresolved when looking at a different configuration altogether'
@@ -1510,8 +369,8 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
             conflictsResult.output.contains('verifyDependencyResolution FAILED')
 
             // different output depending on report task type; same effect
-            conflictsResult.output.contains("test.nebula:foo:{strictly 1.0.0} -> 1.0.0 FAILED") || conflictsResult.output.contains("test.nebula:foo:{strictly 1.0.0} FAILED")
-            conflictsResult.output.contains("test.nebula:foo:{strictly 2.0.0} -> 2.0.0 FAILED") || conflictsResult.output.contains("test.nebula:foo:{strictly 2.0.0} FAILED")
+            conflictsResult.output.contains('test.nebula:foo:{strictly 1.0.0} -> 1.0.0 FAILED') || conflictsResult.output.contains('test.nebula:foo:{strictly 1.0.0} FAILED')
+            conflictsResult.output.contains('test.nebula:foo:{strictly 2.0.0} -> 2.0.0 FAILED') || conflictsResult.output.contains('test.nebula:foo:{strictly 2.0.0} FAILED')
         }
 
         where:
@@ -1545,7 +404,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
                 > Failed to resolve the following dependencies:
                 1. $FAILED_RESOLVE_PREFIX '$dependency' for project
                 """.stripIndent()
-            String gradleExpectedText = "> " + COULD_NOT_FIND + dependency
+            String gradleExpectedText = '> ' + COULD_NOT_FIND + dependency
             int verifierCount = resultsOutput.findAll(verifierExpectedText).size()
             int gradleCount = resultsOutput.findAll(gradleExpectedText).size()
 
@@ -1578,6 +437,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
 
         /** Value type pairing a dependency coordinate with a project name for assertResolutionFailureForDependencyForProjectOneOf. */
         private static final class DependencyProjectPair {
+
             final String dependency
             final String project
 
@@ -1585,12 +445,14 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
                 this.dependency = dependency
                 this.project = project
             }
+
         }
 
         /** Pairs a dependency coordinate with a project name for use in assertResolutionFailureForDependencyForProjectOneOf. */
         static DependencyProjectPair dependencyProjectPair(String dependency, String projectName) {
             return new DependencyProjectPair(dependency, projectName)
         }
+
     }
 
     private static String taskThatRequiresConfigurationDependencies() {
@@ -1624,7 +486,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
                 doLast {
                     def resolvedArtifacts = project.configurations.compileClasspath.resolvedConfiguration.resolvedArtifacts.collect { it.toString() }
                     task.dependenciesAsStrings = resolvedArtifacts
-                    
+
                     println("Resolved artifacts: \${resolvedArtifacts.join(', ')}")
                 }
             }
@@ -1674,8 +536,8 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
             }
             """.stripIndent()
 
-        addSubproject("sub1", subProjectBuildFileContent)
-        addSubproject("sub2", subProjectBuildFileContent)
+        addSubproject('sub1', subProjectBuildFileContent)
+        addSubproject('sub2', subProjectBuildFileContent)
 
         writeHelloWorld(new File(projectDir, 'sub1'))
         writeHelloWorld(new File(projectDir, 'sub2'))
@@ -1687,30 +549,30 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         setupSingleProject()
         settingsFile << "\nincludeBuild('included-project')"
 
-        def includedProjectDir = new File(projectDir, "included-project")
+        def includedProjectDir = new File(projectDir, 'included-project')
         includedProjectDir.mkdirs()
-        def includedProjectBuildFile = new File(includedProjectDir, "build.gradle")
+        def includedProjectBuildFile = new File(includedProjectDir, 'build.gradle')
         includedProjectBuildFile.createNewFile()
         includedProjectBuildFile.text = """
             plugins {
                 id 'java'
             }
             """.stripIndent()
-        def includedProjectSettingsFile = new File(includedProjectDir, "settings.gradle")
+        def includedProjectSettingsFile = new File(includedProjectDir, 'settings.gradle')
         includedProjectSettingsFile.createNewFile()
         includedProjectSettingsFile.text = """
             rootProject.name = 'included-project'
-            
+
             include "sub1"
             include "sub2"
             """.stripIndent()
-        def includedSub1Dir = new File(includedProjectDir, "sub1")
+        def includedSub1Dir = new File(includedProjectDir, 'sub1')
         includedSub1Dir.mkdirs()
-        def includedSub1BuildFiles = new File(includedSub1Dir, "build.gradle")
+        def includedSub1BuildFiles = new File(includedSub1Dir, 'build.gradle')
         includedSub1BuildFiles.text = buildFile.text
-        def includedSub2Dir = new File(includedProjectDir, "sub2")
+        def includedSub2Dir = new File(includedProjectDir, 'sub2')
         includedSub2Dir.mkdirs()
-        def includedSub2BuildFiles = new File(includedSub2Dir, "build.gradle")
+        def includedSub2BuildFiles = new File(includedSub2Dir, 'build.gradle')
         includedSub2BuildFiles.text = buildFile.text
     }
 
@@ -1776,7 +638,7 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
                     resolutionRules files('$rulesJsonFile')
                 }
             }
-      
+
             """.stripIndent()
 
         def subProject1BuildFileContent = """
@@ -1795,13 +657,13 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
             }
             """.stripIndent()
 
-        addSubproject("sub1", subProject1BuildFileContent)
-        addSubproject("sub2", subProject2BuildFileContent)
+        addSubproject('sub1', subProject1BuildFileContent)
+        addSubproject('sub2', subProject2BuildFileContent)
 
         def dependencyLock = new File(projectDir, 'dependencies.lock')
         def dependencyLockSubproject1 = new File(projectDir, 'sub1/dependencies.lock')
         def dependencyLockSubproject2 = new File(projectDir, 'sub2/dependencies.lock')
-        dependencyLock << "{ }"
+        dependencyLock << '{ }'
         dependencyLockSubproject1 << dependencyLockFileContents
 
         def dependencyLockFileContentsSubproject2 = '''\
@@ -1934,4 +796,5 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         !result.output.contains('verifyDependencyResolution was not registered')
         !result.output.contains('FAILURE')
     }
+
 }

--- a/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
+++ b/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
@@ -15,7 +15,17 @@
  *     limitations under the License.
  *
  */
+
 package nebula.plugin.dependencyverifier
+
+import nebula.plugin.BaseIntegrationTestKitSpec
+import nebula.plugin.VerifierOutputAssertionsBase
+import nebula.test.dependencies.DependencyGraphBuilder
+import nebula.test.dependencies.GradleDependencyGenerator
+import nebula.test.dependencies.ModuleBuilder
+import spock.lang.Ignore
+import spock.lang.Subject
+import spock.lang.Unroll
 
 import static nebula.plugin.VerifierOutputAssertionsBase.assertConfigurationCacheStateCouldNotBeStored
 import static nebula.plugin.VerifierOutputAssertionsBase.assertConfigurationCachingIsNotMentioned
@@ -30,15 +40,1147 @@ import static nebula.plugin.dependencyverifier.DependencyResolutionVerifierTest.
 import static nebula.plugin.dependencyverifier.DependencyResolutionVerifierTest.OutputAssertions.assertResolutionFailureMessage
 import static nebula.plugin.dependencyverifier.DependencyResolutionVerifierTest.OutputAssertions.dependencyProjectPair
 
+@Subject(DependencyResolutionVerifierKt)
+class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
+
+    def mavenrepo
+
+    def setup() {
+        def graph = new DependencyGraphBuilder()
+                .addModule('test.nebula:a:1.0.0')
+                .addModule('test.nebula:b:1.0.0')
+                .addModule('test.nebula:c:1.1.0')
+                .addModule(new ModuleBuilder('has.missing.transitive:a:1.0.0').addDependency('transitive.not.available:a:1.0.0').build())
+                .build()
+
+        mavenrepo = new GradleDependencyGenerator(graph, "${projectDir}/testrepogen")
+        mavenrepo.generateTestMavenRepo()
+
+        def transitiveNotAvailableDep = new File(mavenrepo.getMavenRepoDir(), "transitive/not/available/a")
+        transitiveNotAvailableDep.deleteDir() // to create a missing transitive dependency
+    }
+
+    @Unroll
+    def 'no verification errors - #description'() {
+        given:
+        setupSingleProject()
+
+        when:
+        def results = runTasks(*tasks)
+
+        then:
+        !results.output.contains('FAILURE')
+        assertNoConfigurationCacheStoringIssues(results.output)
+
+        where:
+        tasks                                                   | description
+        ['dependencies', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
+    }
+
+    @Unroll
+    def 'error displayed when direct dependency is missing - #description'() {
+        given:
+        setupSingleProject()
+
+        buildFile << """
+            dependencies {
+                implementation 'not.available:a:1.0.0' // dependency is not found
+            }
+            """.stripIndent()
+
+        when:
+        def results = runTasksAndFail(*tasks)
+
+        then:
+        results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForDependency(results.output, "not.available:a:1.0.0")
+
+        where:
+        tasks                                                                                | description
+        ['build']                                                                            | 'resolve dependencies naturally'
+        ['dependencies', '--configuration', 'compileClasspath', 'build', 'buildEnvironment'] | 'explicitly resolve as part of task chain'
+    }
+
+    def 'error displayed when direct dependency is missing - reporting task only'() {
+        given:
+        setupSingleProject()
+
+        buildFile << """
+            dependencies {
+                implementation 'not.available:a:1.0.0' // dependency is not found
+            }
+            """.stripIndent()
+
+        when:
+        def results = runTasksAndFail(*tasks)
+
+        then:
+        results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForDependency(results.output, "not.available:a:1.0.0")
+
+        where:
+        tasks                                                   | description
+        ['dependencies', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
+    }
+
+    @Unroll
+    def 'error displayed when transitive dependency is missing - #description'() {
+        given:
+        setupSingleProject()
+
+        buildFile << """
+            dependencies {
+                implementation 'has.missing.transitive:a:1.0.0' // transitive dependency is missing
+            }
+            """.stripIndent()
+
+        when:
+        def results = runTasksAndFail(*tasks)
+
+        then:
+        results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForDependency(results.output, "transitive.not.available:a:1.0.0")
+
+        where:
+        tasks                                                                                | description
+        ['build']                                                                            | 'resolve dependencies naturally'
+        ['dependencies', '--configuration', 'compileClasspath', 'build', 'buildEnvironment'] | 'explicitly resolve as part of task chain'
+    }
+
+    def 'error displayed when transitive dependency is missing - reporting task only'() {
+        given:
+        setupSingleProject()
+
+        buildFile << """
+            dependencies {
+                implementation 'has.missing.transitive:a:1.0.0' // transitive dependency is missing
+            }
+            """.stripIndent()
+
+        when:
+        def results = runTasksAndFail(*tasks)
+
+        then:
+        results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForDependency(results.output, "transitive.not.available:a:1.0.0")
+
+        where:
+        tasks                                                   | description
+        ['dependencies', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
+    }
+
+    @Unroll
+    def 'error displayed when version is missing - #description'() {
+        given:
+        setupSingleProject()
+
+        buildFile << """
+            dependencies {
+                implementation 'test.nebula:c' // version is missing
+                implementation 'test.nebula:d' // version is missing
+            }
+            """.stripIndent()
+
+        when:
+        def results = runTasksAndFail(*tasks)
+
+        then:
+        results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForMissingVersionDependencies(results.output, ["test.nebula:c", "test.nebula:d"])
+
+        where:
+        tasks                                                                                | description
+        ['build']                                                                            | 'resolve dependencies naturally'
+        ['dependencies', '--configuration', 'compileClasspath', 'build', 'buildEnvironment'] | 'explicitly resolve as part of task chain'
+    }
+
+    def 'error displayed when version is missing - reporting task only'() {
+        given:
+        setupSingleProject()
+
+        buildFile << """
+            dependencies {
+                implementation 'test.nebula:c' // version is missing
+                implementation 'test.nebula:d' // version is missing
+            }
+            """.stripIndent()
+
+        when:
+        def results = runTasksAndFail(*tasks)
+
+        then:
+        results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForMissingVersionDependencies(results.output, ["test.nebula:c", "test.nebula:d"])
+
+        where:
+        tasks                                                   | description
+        ['dependencies', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
+    }
+
+    @Unroll
+    def 'error displayed when a dependency is not found and needed at compilation - #description'() {
+        given:
+        setupSingleProject()
+        buildFile << """
+            dependencies {
+                implementation 'junit:junit:999.99.9' // version is invalid yet needed for compilation
+            }
+            """.stripIndent()
+        writeUnitTest() // valid version of the junit library is not in the dependency declaration
+
+        when:
+        def results = runTasksAndFail(*tasks)
+
+        then:
+        results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForDependency(results.output, "junit:junit:999.99.9")
+
+        where:
+        tasks                                                                                | description
+        ['build']                                                                            | 'resolve dependencies naturally'
+        ['dependencies', '--configuration', 'compileClasspath', 'build', 'buildEnvironment'] | 'explicitly resolve as part of task chain'
+    }
+
+    def 'error displayed when a dependency is not found and needed at compilation - reporting task only'() {
+        given:
+        setupSingleProject()
+        buildFile << """
+            dependencies {
+                implementation 'junit:junit:999.99.9' // version is invalid yet needed for compilation
+            }
+            """.stripIndent()
+        writeUnitTest() // valid version of the junit library is not in the dependency declaration
+
+        when:
+        def results = runTasksAndFail(*tasks)
+
+        then:
+        results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForDependency(results.output, "junit:junit:999.99.9")
+
+        where:
+        tasks                                                   | description
+        ['dependencies', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
+    }
+
+    @Unroll
+    def 'multiproject: missing direct dependencies - #description'() {
+        given:
+        setupMultiProject()
+
+        new File(projectDir, 'sub1/build.gradle') << """ \
+        dependencies {
+            implementation 'not.available:apricot:1.0.0' // dependency is not found
+        }
+        """.stripIndent()
+
+        new File(projectDir, 'sub2/build.gradle') << """ \
+        dependencies {
+            implementation 'not.available:banana-leaf:2.0.0' // dependency is not found
+        }
+        """.stripIndent()
+
+        when:
+        def results = runTasksAndFail(*tasks)
+
+        then:
+        results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForDependencyForProject(results.output, "not.available:apricot:1.0.0", "sub1")
+
+        where:
+        tasks                                                                                      | description
+        ['build']                                                                                  | 'resolve dependencies naturally'
+        ['dependenciesForAll', '--configuration', 'compileClasspath', 'build', 'buildEnvironment'] | 'explicitly resolve as part of task chain'
+    }
+
+    def 'multiproject: missing direct dependencies - reporting task only'() {
+        given:
+        setupMultiProject()
+
+        new File(projectDir, 'sub1/build.gradle') << """ \
+        dependencies {
+            implementation 'not.available:apricot:1.0.0' // dependency is not found
+        }
+        """.stripIndent()
+
+        new File(projectDir, 'sub2/build.gradle') << """ \
+        dependencies {
+            implementation 'not.available:banana-leaf:2.0.0' // dependency is not found
+        }
+        """.stripIndent()
+
+        when:
+        def results = runTasksAndFail(*tasks)
+
+        then:
+        results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForDependencyForProject(results.output, "not.available:apricot:1.0.0", "sub1")
+
+        where:
+        tasks                                                         | description
+        ['dependenciesForAll', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
+    }
+
+    @Unroll
+    def 'multiproject: handles worker threads from spotbugs - #description'() {
+        given:
+        buildFile << """
+            buildscript {
+                repositories { maven { url = "https://plugins.gradle.org/m2/" } }
+                dependencies {
+                     classpath "com.github.spotbugs:com.github.spotbugs.gradle.plugin:6.4.8"
+                }
+            }            
+            """.stripIndent()
+        setupMultiProject()
+        buildFile << """
+            subprojects {
+                apply plugin: "com.github.spotbugs"
+                repositories {
+                    mavenCentral()
+                }
+                configurations.named('spotbugs').configure {
+                  resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+                       if (details.requested.group == 'org.ow2.asm') {
+                            details.useVersion '9.9'
+                            details.because "Asm 9.9 is required for JDK 25 support"
+                      }
+                  }
+                }
+            }
+            """.stripIndent()
+
+        new File(projectDir, 'sub1/build.gradle') << """ \
+            dependencies {
+                testImplementation 'junit:junit:4.12'
+            }
+            """.stripIndent()
+
+        new File(projectDir, 'sub2/build.gradle') << """ \
+            dependencies {
+                testImplementation 'junit:junit:4.12'
+            }
+            """.stripIndent()
+
+        when:
+        def results = runTasks(*tasks, '--warning-mode', 'all')
+
+        then:
+        !results.output.contains('FAILURE')
+        assertNoConfigurationCacheStoringIssues(results.output)
+        !results.output.contains('was resolved without accessing the project in a safe manner')
+
+        where:
+        tasks                                                         | description
+        ['spotbugsMain']                                              | 'calling spotbugsMain'
+        ['build']                                                     | 'resolve dependencies naturally'
+    }
+
+    def 'multiproject: handles worker threads from spotbugs - reporting task only'() {
+        given:
+        buildFile << """
+            buildscript {
+                repositories { maven { url = "https://plugins.gradle.org/m2/" } }
+                dependencies {
+                     classpath "com.github.spotbugs:com.github.spotbugs.gradle.plugin:6.4.8"
+                }
+            }            
+            """.stripIndent()
+        setupMultiProject()
+        buildFile << """
+            subprojects {
+                apply plugin: "com.github.spotbugs"
+                repositories {
+                    mavenCentral()
+                }
+                configurations.named('spotbugs').configure {
+                  resolutionStrategy.eachDependency { DependencyResolveDetails details ->
+                       if (details.requested.group == 'org.ow2.asm') {
+                            details.useVersion '9.9'
+                            details.because "Asm 9.9 is required for JDK 25 support"
+                      }
+                  }
+                }
+            }
+            """.stripIndent()
+
+        new File(projectDir, 'sub1/build.gradle') << """ \
+            dependencies {
+                testImplementation 'junit:junit:4.12'
+            }
+            """.stripIndent()
+
+        new File(projectDir, 'sub2/build.gradle') << """ \
+            dependencies {
+                testImplementation 'junit:junit:4.12'
+            }
+            """.stripIndent()
+
+        when:
+        def results = runTasks(*tasks, '--warning-mode', 'all')
+
+        then:
+        !results.output.contains('FAILURE')
+        assertNoConfigurationCacheStoringIssues(results.output)
+        !results.output.contains('was resolved without accessing the project in a safe manner')
+
+        where:
+        tasks | description
+        ['dependenciesForAll', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
+    }
+
+    @Unroll
+    def 'multiproject: works for parallel builds - #description'() {
+        given:
+        setupMultiProject()
+
+        new File(projectDir, 'sub1/build.gradle') << """ \
+        dependencies {
+            implementation 'not.available:apricot:1.0.0' // dependency is not found
+        }
+        """.stripIndent()
+
+        new File(projectDir, 'sub2/build.gradle') << """ \
+        dependencies {
+            implementation 'not.available:banana-leaf:2.0.0' // dependency is not found
+        }
+        """.stripIndent()
+
+        when:
+        def results = runTasksAndFail(*tasks, '--parallel')
+
+        then:
+        results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForOneOfTheseDependencies(results.output, [
+                dependencyProjectPair("not.available:apricot:1.0.0", "sub1"),
+                dependencyProjectPair("not.available:banana-leaf:2.0.0", "sub2")
+        ])
+
+        where:
+        tasks                                                                                      | description
+        ['build']                                                                                  | 'resolve dependencies naturally'
+        ['dependenciesForAll', '--configuration', 'compileClasspath', 'build', 'buildEnvironment'] | 'explicitly resolve as part of task chain'
+    }
+
+    def 'multiproject: works for parallel builds - reporting task only'() {
+        given:
+        setupMultiProject()
+
+        new File(projectDir, 'sub1/build.gradle') << """ \
+        dependencies {
+            implementation 'not.available:apricot:1.0.0' // dependency is not found
+        }
+        """.stripIndent()
+
+        new File(projectDir, 'sub2/build.gradle') << """ \
+        dependencies {
+            implementation 'not.available:banana-leaf:2.0.0' // dependency is not found
+        }
+        """.stripIndent()
+
+        when:
+        def results = runTasksAndFail(*tasks, '--parallel')
+
+        then:
+        results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCachingIsNotMentioned(results.output)
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForOneOfTheseDependencies(results.output, [
+                dependencyProjectPair("not.available:apricot:1.0.0", "sub1"),
+                dependencyProjectPair("not.available:banana-leaf:2.0.0", "sub2")
+        ])
+
+        where:
+        tasks                                                         | description
+        ['dependenciesForAll', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
+    }
+
+    @Unroll
+    def 'missing a dependency declaration is not caught - #description'() {
+        given:
+        setupSingleProject()
+        writeUnitTest() // junit library is not in the dependency declaration
+
+        when:
+        def results = runTasksAndFail(*tasks)
+
+        then:
+        results.output.contains('FAILURE')
+        assertNoResolutionFailureMessage(results.output)
+
+        where:
+        tasks                                                                                | description
+        ['build']                                                                            | 'resolve dependencies naturally'
+        ['dependencies', '--configuration', 'compileClasspath', 'build', 'buildEnvironment'] | 'explicitly resolve as part of task chain'
+    }
+
+    @Unroll
+    def 'missing a dependency declaration is not caught - reporting task only'() {
+        given:
+        setupSingleProject()
+        writeUnitTest() // junit library is not in the dependency declaration
+
+        when:
+        def results = runTasks(*tasks)
+
+        then:
+        !results.output.contains('FAILURE')
+        assertNoConfigurationCacheStoringIssues(results.output)
+        assertNoResolutionFailureMessage(results.output)
+
+        where:
+        tasks                                                   | description
+        ['dependencies', '--configuration', 'compileClasspath'] | 'explicitly resolve dependencies'
+    }
+
+    @Unroll
+    def 'specify configurations to ignore via property via #setupStyle'() {
+        given:
+        setupSingleProject()
+
+        if (setupStyle == 'properties file') {
+            def file = new File("${projectDir}/gradle.properties")
+            file << """
+                dependencyResolutionVerifier.configurationsToExclude=specialConfig,otherSpecialConfig
+                """.stripIndent()
+        }
+
+        buildFile << """
+            configurations {
+                specialConfig
+                otherSpecialConfig
+            }
+            dependencies {
+                specialConfig 'not.available:apricot:1.0.0' // not available
+                otherSpecialConfig 'not.available:banana-leaf:2.0.0' // not available
+            }
+            """.stripIndent()
+
+        when:
+        def tasks = ['dependencies', '--configuration', 'compileClasspath']
+        if (setupStyle == 'command line') {
+            tasks += '-PdependencyResolutionVerifier.configurationsToExclude=specialConfig,otherSpecialConfig'
+        }
+        def results = runTasks(*tasks)
+
+        then:
+        assertNoResolutionFailureMessage(results.output)
+
+        where:
+        setupStyle << ['command line', 'properties file']
+    }
+
+    @Unroll
+    def 'displays error once with finalizers - #tasks'() {
+        given:
+        setupSingleProject()
+
+        buildFile << """
+            dependencies {
+                implementation 'not.available:a'
+            }
+            task myFinalizingTask {
+                println "Here's a great finalizing message"
+            }
+            task goodbye {
+                println "Goodbye!"
+            }
+            project.tasks.configureEach { Task task ->
+                if (task.name != 'myFinalizingTask' && task.name != 'clean') {
+                    task.finalizedBy project.tasks.named('myFinalizingTask')
+                }
+                if (task.name != 'myFinalizingTask' && task.name != 'goodbye' && task.name != 'clean') {
+                    task.finalizedBy project.tasks.named('goodbye')
+                }
+            }
+            """.stripIndent()
+
+        when:
+        def results = runTasksAndFail(*tasks)
+
+        then:
+        results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
+        assertResolutionFailureMessage(results.output)
+        assertFailureMessageIsDisplayedOnce(results.output, "not.available:a")
+
+        where:
+        tasks << [['build'], ['build', '--parallel']]
+    }
+
+    @Unroll
+    def 'handles task configuration issue due to #failureType'() {
+        given:
+        setupSingleProject()
+        setupTaskThatRequiresResolvedConfiguration(buildFile)
+
+        buildFile << """
+            dependencies {
+                implementation '$dependency'
+            }
+            """.stripIndent()
+
+        when:
+        def results = runTasksAndFail('build')
+
+        then:
+        assert results.output.contains('FAILURE')
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForDependency(results.output, actualMissingDep ?: dependency)
+
+        where:
+        failureType                | dependency                       | actualMissingDep
+        'missing version'          | 'not.available:a'                | null
+        'direct dep not found'     | 'not.available:a:1.0.0'          | null
+        'transitive dep not found' | 'has.missing.transitive:a:1.0.0' | 'transitive.not.available:a:1.0.0'
+    }
+
+    @Unroll
+    def 'handles task configuration issue due to #failureType - multiproject'() {
+        given:
+        setupMultiProject()
+
+        def sub1BuildFile = new File(projectDir, 'sub1/build.gradle')
+        def sub2BuildFile = new File(projectDir, 'sub2/build.gradle')
+
+        setupTaskThatRequiresResolvedConfiguration(sub1BuildFile)
+        setupTaskThatRequiresResolvedConfiguration(sub2BuildFile)
+
+        sub1BuildFile << """ \
+        dependencies {
+            implementation '$dependency'
+        }
+        """.stripIndent()
+
+        def sub2Dependency = dependency.replace(':a', ':b')
+        sub2BuildFile << """
+        dependencies {
+            implementation '$sub2Dependency'
+        }
+        """.stripIndent()
+
+        when:
+        def results = runTasksAndFail('build')
+
+        then:
+        assert results.output.contains('FAILURE')
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForDependencyForProject(results.output, actualMissingDep ?: dependency, "sub1")
+        assert !results.output.contains("for project 'sub2'")
+
+        where:
+        failureType                | dependency                       | actualMissingDep
+        'missing version'          | 'not.available:a'                | null
+        'direct dep not found'     | 'not.available:a:1.0.0'          | null
+        'transitive dep not found' | 'has.missing.transitive:a:1.0.0' | 'transitive.not.available:a:1.0.0'
+    }
+
+    @Unroll
+    def 'handles task configuration issue due to #failureType - multiproject and parallel'() {
+        given:
+        setupMultiProject()
+
+        def sub1BuildFile = new File(projectDir, 'sub1/build.gradle')
+        def sub2BuildFile = new File(projectDir, 'sub2/build.gradle')
+
+        setupTaskThatRequiresResolvedConfiguration(sub1BuildFile)
+        setupTaskThatRequiresResolvedConfiguration(sub2BuildFile)
+
+        sub1BuildFile << """
+        dependencies {
+            implementation '$dependency'
+        }
+        """.stripIndent()
+
+        def sub2Dependency = dependency.replace(':a', ':b')
+        sub2BuildFile << """
+        dependencies {
+            implementation '$sub2Dependency'
+        }
+        """.stripIndent()
+
+        when:
+        def results = runTasksAndFail('build')
+
+        then:
+        assert results.output.contains('FAILURE')
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForDependencyForProject(results.output, actualMissingDep ?: dependency, "sub1")
+        assert !results.output.contains("for project 'sub2'")
+
+        where:
+        failureType                | dependency                       | actualMissingDep
+        'missing version'          | 'not.available:a'                | null
+        'direct dep not found'     | 'not.available:a:1.0.0'          | null
+        'transitive dep not found' | 'has.missing.transitive:a:1.0.0' | 'transitive.not.available:a:1.0.0'
+    }
+
+    @Unroll
+    def 'uses extension for #description'() {
+        given:
+        setupSingleProject()
+
+        def configurationName = description == 'configurationsToExclude'
+                ? 'myConfig' : 'implementation'
+
+        buildFile << """
+            configurations { myConfig }
+            dependencies {
+                $configurationName 'not.available:a'
+            }
             import nebula.plugin.dependencyverifier.DependencyResolutionVerifierExtension
-import nebula.plugin.BaseIntegrationTestKitSpec
-import nebula.plugin.VerifierOutputAssertionsBase
-import nebula.test.dependencies.DependencyGraphBuilder
-import nebula.test.dependencies.GradleDependencyGenerator
-import nebula.test.dependencies.ModuleBuilder
-import spock.lang.Ignore
-import spock.lang.Subject
-import spock.lang.Unroll
+            plugins.withId('com.netflix.nebula.dependency-lock') {
+                def extension = extensions.getByType(DependencyResolutionVerifierExtension.class)
+                def list = new ArrayList<>()
+                $extensionSetting
+            }
+            """.stripIndent()
+
+        when:
+        def results
+        if (willFail) {
+            results = runTasksAndFail('dependencies')
+        } else {
+            results = runTasks('dependencies')
+        }
+
+        then:
+        if (seeErrors) {
+            assertResolutionFailureMessage(results.output)
+            assertResolutionFailureForDependency(results.output, "not.available:a")
+            if (description == 'missingVersionsMessageAddition') {
+                assert results.output.contains('You can find additional help at...'),
+                        "Expected output to contain missingVersionsMessageAddition: 'You can find additional help at...'"
+            }
+        } else {
+            assertNoResolutionFailureMessage(results.output)
+        }
+
+        where:
+        extensionSetting                                                                  | description                      | willFail | seeErrors
+        'extension.missingVersionsMessageAddition = "You can find additional help at..."' | 'missingVersionsMessageAddition' | true     | true
+        'extension.shouldFailTheBuild = false'                                            | 'shouldFailTheBuild'             | false    | true
+        "list.addAll('myConfig')\n\textension.configurationsToExclude = list"             | 'configurationsToExclude'        | false    | false
+        "list.addAll('dependencies')\n\textension.tasksToExclude = list"                  | 'tasksToExclude'                 | false    | false
+    }
+
+    def 'unresolved dependencies output includes missingVersionsMessageAddition when some dependencies lack a version'() {
+        given:
+        setupSingleProject()
+        def customAddition = 'Custom help: http://example.com/dependency-help'
+        buildFile << """
+            dependencies {
+                implementation 'not.available:a'
+            }
+            dependencyResolutionVerifierExtension {
+                missingVersionsMessageAddition = '$customAddition'
+            }
+        """.stripIndent()
+
+        when:
+        def results = runTasksAndFail('dependencies')
+
+        then:
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForDependency(results.output, 'not.available:a')
+        assert results.output.contains(customAddition),
+                "Expected output to contain missingVersionsMessageAddition: ${customAddition}"
+    }
+
+    def 'verifier skips configurations in the skip list (e.g. configurationsToExclude)'() {
+        given:
+        setupSingleProject()
+        new File(projectDir, 'gradle.properties') << """
+            dependencyResolutionVerifier.configurationsToExclude=skipMe
+        """.stripIndent()
+        buildFile << """
+            configurations {
+                skipMe {
+                    canBeResolved = true
+                }
+            }
+            dependencies {
+                skipMe 'not.available:unresolvable:1.0.0'
+            }
+        """.stripIndent()
+
+        when:
+        def results = runTasks('dependencies', '--configuration', 'compileClasspath')
+
+        then:
+        assert !results.output.toString().contains('FAILURE'):
+                "Verifier should skip skipMe via configurationsToExclude; without skip we would resolve it and fail"
+        assertNoConfigurationCacheStoringIssues(results.output)
+    }
+
+    def 'strict platform constraint aligns versions and verifier does not fail on non-selected versions'() {
+        given:
+        setupSingleProject()
+        buildFile << """
+            repositories {
+                mavenCentral()
+            }
+            dependencies {
+                implementation 'org.springframework:spring-core:5.2.9.RELEASE'
+                implementation 'org.springframework:spring-core:5.2.12.RELEASE'
+                implementation platform('org.springframework:spring-framework-bom:5.2.14.RELEASE')
+                implementation 'org.springframework:spring-context'
+            }
+        """.stripIndent()
+
+        when:
+        def results = runTasks('dependencies', '--configuration', 'runtimeClasspath')
+
+        then: 'we do not see failures'
+        !results.output.contains('FAILURE')
+        !results.output.contains('verifyDependencyResolution FAILED')
+        !results.output.contains('Failed to resolve the following dependencies:')
+
+        and: 'we see conflict-resolved versions resolve to a single version'
+        results.output.contains('org.springframework:spring-core:5.2.9.RELEASE -> 5.2.14.RELEASE')
+        results.output.contains('org.springframework:spring-core:5.2.12.RELEASE -> 5.2.14.RELEASE')
+        results.output.contains('org.springframework:spring-core:5.2.14.RELEASE')
+
+        and: 'we do not see resolved final path at lower non-selected versions'
+        !results.output.contains('org.springframework:spring-core:5.2.9.RELEASE\n')
+        !results.output.contains('org.springframework:spring-core:5.2.12.RELEASE\n')
+
+        and: 'we see version provided by BOM successfully'
+        results.output.contains('org.springframework:spring-context -> 5.2.14.RELEASE\n')
+
+        and: 'we do not see issues about dependencies missing a version, which would be provided by the BOM'
+        !results.output.contains('The following dependencies are missing a version:')
+    }
+
+    def 'handles root and subproject of the same name'() {
+        given:
+        setupMultiProject()
+
+        def sub1BuildFile = new File(projectDir, 'sub1/build.gradle')
+        sub1BuildFile << """
+        dependencies {
+            implementation 'not.available:a:1.0.0' // dependency is not found
+        }
+        """.stripIndent()
+
+        settingsFile.createNewFile()
+        settingsFile.text = """
+            rootProject.name='sub1'
+            include "sub1"
+            include "sub2"
+            """.stripIndent()
+
+        when:
+        def results = runTasksAndFail('build')
+
+        then:
+        results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
+        assertResolutionFailureMessage(results.output)
+        assertFailureMessageIsDisplayedOnce(results.output, "not.available:a:1.0.0")
+        assertResolutionFailureForDependencyForProject(results.output, "not.available:a:1.0.0", "sub1")
+    }
+
+    def 'handles build failure from task configuration issue'() {
+        given:
+        setupSingleProject()
+        buildFile << """
+            dependencies {
+                implementation 'not.available:a:1.0.0' // dependency is not found
+            }
+            task goodbye {
+                println "Goodbye!"
+            }
+            build.finalizedBy project.tasks.named('goodbye') onlyIf {
+                project.configurations.compileClasspath.resolvedConfiguration.resolvedArtifacts.collect {it.name}.contains('bananan')
+            }
+            """.stripIndent()
+
+        when:
+        def results = runTasksAndFail('build')
+
+        then:
+        results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
+        assertResolutionFailureMessage(results.output)
+        assertFailureMessageIsDisplayedOnce(results.output, "not.available:a:1.0.0")
+        assertResolutionFailureForDependency(results.output, "not.available:a:1.0.0")
+    }
+
+    def 'handles task that requires resolved configuration with no issues'() {
+        given:
+        setupSingleProject()
+
+        buildFile << """
+            ${taskThatRequiresConfigurationDependencies()}
+            """.stripIndent()
+
+        when:
+        def results = runTasks('build')
+
+        then:
+        assert !results.output.contains('FAILURE')
+        assertNoConfigurationCacheStoringIssues(results.output)
+    }
+
+    @Unroll
+    def 'handles task that requires resolved configuration with an issue due to #failureType'() {
+        given:
+        setupSingleProject()
+
+        buildFile << """
+            dependencies {
+                implementation '$dependency'
+            }
+            ${taskThatRequiresConfigurationDependencies()}
+            """.stripIndent()
+
+        when:
+        def results = runTasksAndFail('build')
+
+        then:
+        assert results.output.contains('FAILURE')
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForDependency(results.output, actualMissingDep ?: dependency)
+
+        where:
+        failureType                | dependency                       | actualMissingDep
+        'missing version'          | 'not.available:a'                | null
+        'direct dep not found'     | 'not.available:a:1.0.0'          | null
+        'transitive dep not found' | 'has.missing.transitive:a:1.0.0' | 'transitive.not.available:a:1.0.0'
+    }
+
+    @Unroll
+    def 'handles task that requires resolved configuration with an issue due to #failureType - multiproject'() {
+        given:
+        setupMultiProject()
+
+        def sub1BuildFile = new File(projectDir, 'sub1/build.gradle')
+        def sub2BuildFile = new File(projectDir, 'sub2/build.gradle')
+
+        sub1BuildFile << """ \
+        dependencies {
+            implementation '$dependency'
+        }
+        ${taskThatRequiresConfigurationDependencies()}
+        """.stripIndent()
+
+        def sub2Dependency = dependency.replace(':a', ':b')
+        sub2BuildFile << """
+        dependencies {
+            implementation '$sub2Dependency'
+        }
+        ${taskThatRequiresConfigurationDependencies()}
+        """.stripIndent()
+
+        when:
+        def results = runTasksAndFail('build')
+
+        then:
+        assert results.output.contains('FAILURE')
+        assertExecutionFailedForTask(results.output)
+        assertConfigurationCacheStateCouldNotBeStored(results.output)
+        assertResolutionFailureForDependencyForProject(results.output, actualMissingDep ?: dependency, "sub1")
+        assert !results.output.contains("for project 'sub2'")
+
+        where:
+        failureType                | dependency                       | actualMissingDep
+        'missing version'          | 'not.available:a'                | null
+        'direct dep not found'     | 'not.available:a:1.0.0'          | null
+        'transitive dep not found' | 'has.missing.transitive:a:1.0.0' | 'transitive.not.available:a:1.0.0'
+    }
+
+    @Unroll
+    def 'handles task that requires resolved configuration with an issue due to #failureType - multiproject and parallel'() {
+        given:
+        setupMultiProject()
+
+        def sub1BuildFile = new File(projectDir, 'sub1/build.gradle')
+        def sub2BuildFile = new File(projectDir, 'sub2/build.gradle')
+
+        sub1BuildFile << """
+        dependencies {
+            implementation '$dependency'
+        }
+        ${taskThatRequiresConfigurationDependencies()}
+        """.stripIndent()
+
+        def sub2Dependency = dependency.replace(':a', ':b')
+        sub2BuildFile << """
+        dependencies {
+            implementation '$sub2Dependency'
+        }
+        ${taskThatRequiresConfigurationDependencies()}
+        """.stripIndent()
+
+        when:
+        def results = runTasksAndFail('build')
+
+        then:
+        assert results.output.contains('FAILURE')
+        assertResolutionFailureMessage(results.output)
+        assertResolutionFailureForDependencyForProject(results.output, actualMissingDep ?: dependency, "sub1")
+        assert !results.output.contains("for project 'sub2'")
+
+        where:
+        failureType                | dependency                       | actualMissingDep
+        'missing version'          | 'not.available:a'                | null
+        'direct dep not found'     | 'not.available:a:1.0.0'          | null
+        'transitive dep not found' | 'has.missing.transitive:a:1.0.0' | 'transitive.not.available:a:1.0.0'
+    }
+
+    @Unroll
+    def 'resolved versions are not equal to locked versions because locked versions are not aligned - core alignment #coreAlignment - core locking #coreLocking'() {
+        given:
+        setupSingleProjectWithLockedVersionsThatAreNotAligned()
+
+        when:
+        def flags = ["-Dnebula.features.coreAlignmentSupport=${coreAlignment}", "-Dnebula.features.coreLockingSupport=${coreLocking}"]
+        def insightResults = runTasksAndFail('dependencyInsight', '--dependency', 'test.nebula', *flags)
+        def results = runTasksAndFail('dependencies', '--configuration', 'compileClasspath', *flags)
+
+        then:
+        insightResults.output.contains('test.nebula:a:1.1.0 -> 1.2.0\n')
+        insightResults.output.contains('test.nebula:b:1.2.0\n')
+        insightResults.output.contains('test.nebula:c:1.1.0 -> 1.2.0\n')
+
+        insightResults.output.contains('FAILED')
+
+        insightResults.output.contains("Dependency lock state is out of date:")
+        insightResults.output.contains("Resolved 'test.nebula:a:1.2.0' instead of locked version '1.1.0' for project")
+        insightResults.output.contains("Resolved 'test.nebula:c:1.2.0' instead of locked version '1.1.0' for project")
+        insightResults.output.contains("Resolved 'test.nebula:d:1.2.0' instead of locked version '1.1.0' for project")
+        insightResults.output.contains('Please update your dependency locks or your build file constraints.')
+
+        results.output.contains('FAILED')
+
+        results.output.contains("Dependency lock state is out of date:")
+        results.output.contains("Resolved 'test.nebula:a:1.2.0' instead of locked version '1.1.0' for project")
+        results.output.contains("Resolved 'test.nebula:c:1.2.0' instead of locked version '1.1.0' for project")
+        results.output.contains("Resolved 'test.nebula:d:1.2.0' instead of locked version '1.1.0' for project")
+        results.output.contains('Please update your dependency locks or your build file constraints.')
+
+        where:
+        coreAlignment | coreLocking
+        true          | false
+    }
+
+    @Unroll
+    def 'resolved versions are not equal to locked versions - handles unlocked transitives - core alignment #coreAlignment - core locking #coreLocking'() {
+        given:
+        setupSingleProjectWithLockedVersionsThatAreNotAligned()
+
+        when:
+        def flags = ["-Dnebula.features.coreAlignmentSupport=${coreAlignment}", "-Dnebula.features.coreLockingSupport=${coreLocking}"]
+        runTasks('generateLock', 'saveLock', *flags) // without locking transitives
+        def results = runTasks('dependencies', '--configuration', 'compileClasspath', *flags)
+
+        then:
+        results.output.contains('SUCCESS')
+
+        where:
+        coreAlignment | coreLocking
+        true          | false
+    }
+
+    @Unroll
+    def 'resolved versions are not equal to locked versions with override file - core alignment #coreAlignment - core locking #coreLocking'() {
+        given:
+        setupSingleProjectWithLockedVersionsThatAreNotAligned()
+
+        def graph = new DependencyGraphBuilder()
+                .addModule(new ModuleBuilder('test.nebula:a:1.3.0').addDependency('test.nebula:d:1.3.0').build())
+                .addModule('test.nebula:b:1.3.0')
+                .addModule('test.nebula:c:1.3.0')
+                .build()
+        def updatedmavenrepo = new GradleDependencyGenerator(graph, "$projectDir/testrepogen")
+        updatedmavenrepo.generateTestMavenRepo()
+
+        def dependenciesLockOverride = new File(projectDir, 'override.lock')
+        dependenciesLockOverride << '''
+            { "test.nebula:a": "1.3.0" }
+            '''.stripIndent()
+
+        when:
+        def flags = ['-PdependencyLock.overrideFile=override.lock', "-Dnebula.features.coreAlignmentSupport=${coreAlignment}", "-Dnebula.features.coreLockingSupport=${coreLocking}"]
+        def insightResults = runTasksAndFail('dependencyInsight', '--dependency', 'test.nebula', *flags)
+        def results = runTasksAndFail('dependencies', '--configuration', 'compileClasspath', *flags)
+
+        then:
+        insightResults.output.contains('using override file: override.lock')
+
+        insightResults.output.contains('test.nebula:a:1.1.0 -> 1.3.0\n')
+        insightResults.output.contains('test.nebula:b:1.3.0\n')
+        insightResults.output.contains('test.nebula:c:1.1.0 -> 1.3.0\n')
+        insightResults.output.contains('test.nebula:d:1.3.0\n')
+
+        insightResults.output.contains('FAILED')
+
+        insightResults.output.contains("Dependency lock state is out of date:")
+        !insightResults.output.contains("Resolved 'test.nebula:a:1.3.0' instead of locked version")
+        insightResults.output.contains("Resolved 'test.nebula:b:1.3.0' instead of locked version '1.2.0' for project")
+        insightResults.output.contains("Resolved 'test.nebula:c:1.3.0' instead of locked version '1.1.0' for project")
+        insightResults.output.contains("Resolved 'test.nebula:d:1.3.0' instead of locked version '1.1.0' for project")
+        insightResults.output.contains('Please update your dependency locks or your build file constraints.')
+
+        results.output.contains('FAILED')
+
+        results.output.contains("Dependency lock state is out of date:")
+        !results.output.contains("Resolved 'test.nebula:a:1.3.0' instead of locked version")
+        results.output.contains("Resolved 'test.nebula:b:1.3.0' instead of locked version '1.2.0' for project")
+        results.output.contains("Resolved 'test.nebula:c:1.3.0' instead of locked version '1.1.0' for project")
+        results.output.contains("Resolved 'test.nebula:d:1.3.0' instead of locked version '1.1.0' for project")
+        results.output.contains('Please update your dependency locks or your build file constraints.')
+
+        where:
+        coreAlignment | coreLocking
+        true          | false
+    }
+
+    @Unroll
+    def 'resolved versions are not equal to locked versions - can configure extension messaging - core alignment #coreAlignment - core locking #coreLocking'() {
+        given:
+        setupSingleProjectWithLockedVersionsThatAreNotAligned()
+        def extensionMessage = 'You may see this after changing from Nebula alignment to core Gradle alignment for the first time in this repository'
+        buildFile << """
+            import nebula.plugin.dependencyverifier.DependencyResolutionVerifierExtension
             plugins.withId('com.netflix.nebula.dependency-lock') {
                 def extension = extensions.getByType(DependencyResolutionVerifierExtension.class)
                 extension.resolvedVersionDoesNotEqualLockedVersionMessageAddition = '$extensionMessage'
@@ -70,7 +1212,7 @@ import spock.lang.Unroll
         then:
         results.output.contains('FAILED')
 
-        results.output.contains('Dependency lock state is out of date:')
+        results.output.contains("Dependency lock state is out of date:")
         results.output.contains("Resolved 'test.nebula:a:1.2.0' instead of locked version '1.1.0' for project 'sub1'")
         results.output.contains("Resolved 'test.nebula:c:1.2.0' instead of locked version '1.1.0' for project 'sub1'")
         results.output.contains("Resolved 'test.nebula:d:1.2.0' instead of locked version '1.1.0' for project 'sub1'")
@@ -93,7 +1235,7 @@ import spock.lang.Unroll
         then:
         results.output.contains('FAILED')
 
-        results.output.contains('Dependency lock state is out of date:')
+        results.output.contains("Dependency lock state is out of date:")
 
         results.output.contains("Resolved 'test.nebula:a:1.2.0' instead of locked version '1.1.0' for project 'sub1'")
         results.output.contains("Resolved 'test.nebula:c:1.2.0' instead of locked version '1.1.0' for project 'sub1'")
@@ -182,13 +1324,13 @@ import spock.lang.Unroll
         new File(projectDir, 'global.lock').text = globalLockText
 
         when:
-        def flags = ['-Dnebula.features.coreAlignmentSupport=true', '-Dnebula.features.coreLockingSupport=false']
+        def flags = ["-Dnebula.features.coreAlignmentSupport=true", "-Dnebula.features.coreLockingSupport=false"]
         def results = runTasksAndFail('dependenciesForAll', '--configuration', 'compileClasspath', *flags)
 
         then:
         results.output.contains('FAILED')
 
-        results.output.contains('Dependency lock state is out of date:')
+        results.output.contains("Dependency lock state is out of date:")
 
         results.output.contains("Resolved 'test.nebula:a:1.2.0' instead of locked version '1.1.0' for project 'sub1'")
         results.output.contains("Resolved 'test.nebula:c:1.2.0' instead of locked version '1.1.0' for project 'sub1'")
@@ -319,9 +1461,9 @@ import spock.lang.Unroll
                 }
                 """.stripIndent()
 
-        def sub1Dir = new File(projectDir, 'included-project/sub1')
+        def sub1Dir = new File(projectDir, "included-project/sub1")
         sub1Dir.mkdirs()
-        def sub1BuildFile = new File(sub1Dir, 'build.gradle')
+        def sub1BuildFile = new File(sub1Dir, "build.gradle")
         sub1BuildFile << """
                 dependencies {
                     implementation 'not.available:b:1.0.0' // dependency is not found either
@@ -333,7 +1475,7 @@ import spock.lang.Unroll
 
         then:
         assert results.output.contains('> Task :included-project:sub1:dependencies')
-        assertResolutionFailureForDependencyForProject(results.output, 'not.available:b:1.0.0', 'sub1')
+        assertResolutionFailureForDependencyForProject(results.output, "not.available:b:1.0.0", "sub1")
         assert results.output.contains('FAIL')
     }
 
@@ -356,7 +1498,7 @@ import spock.lang.Unroll
             !noIssuesResult.output.contains('FAILURE')
             !noIssuesResult.output.contains('verifyDependencyResolution FAILED')
 
-            !noIssuesResult.output.contains('Failed to resolve')
+            !noIssuesResult.output.contains("Failed to resolve")
         }
 
         and: 'in particular, the synthetic {strictly 2.0.0} constraint is not falsely reported as unresolved when looking at a different configuration altogether'
@@ -368,8 +1510,8 @@ import spock.lang.Unroll
             conflictsResult.output.contains('verifyDependencyResolution FAILED')
 
             // different output depending on report task type; same effect
-            conflictsResult.output.contains('test.nebula:foo:{strictly 1.0.0} -> 1.0.0 FAILED') || conflictsResult.output.contains('test.nebula:foo:{strictly 1.0.0} FAILED')
-            conflictsResult.output.contains('test.nebula:foo:{strictly 2.0.0} -> 2.0.0 FAILED') || conflictsResult.output.contains('test.nebula:foo:{strictly 2.0.0} FAILED')
+            conflictsResult.output.contains("test.nebula:foo:{strictly 1.0.0} -> 1.0.0 FAILED") || conflictsResult.output.contains("test.nebula:foo:{strictly 1.0.0} FAILED")
+            conflictsResult.output.contains("test.nebula:foo:{strictly 2.0.0} -> 2.0.0 FAILED") || conflictsResult.output.contains("test.nebula:foo:{strictly 2.0.0} FAILED")
         }
 
         where:
@@ -403,7 +1545,7 @@ import spock.lang.Unroll
                 > Failed to resolve the following dependencies:
                 1. $FAILED_RESOLVE_PREFIX '$dependency' for project
                 """.stripIndent()
-            String gradleExpectedText = '> ' + COULD_NOT_FIND + dependency
+            String gradleExpectedText = "> " + COULD_NOT_FIND + dependency
             int verifierCount = resultsOutput.findAll(verifierExpectedText).size()
             int gradleCount = resultsOutput.findAll(gradleExpectedText).size()
 
@@ -436,7 +1578,6 @@ import spock.lang.Unroll
 
         /** Value type pairing a dependency coordinate with a project name for assertResolutionFailureForDependencyForProjectOneOf. */
         private static final class DependencyProjectPair {
-
             final String dependency
             final String project
 
@@ -444,14 +1585,12 @@ import spock.lang.Unroll
                 this.dependency = dependency
                 this.project = project
             }
-
         }
 
         /** Pairs a dependency coordinate with a project name for use in assertResolutionFailureForDependencyForProjectOneOf. */
         static DependencyProjectPair dependencyProjectPair(String dependency, String projectName) {
             return new DependencyProjectPair(dependency, projectName)
         }
-
     }
 
     private static String taskThatRequiresConfigurationDependencies() {
@@ -485,7 +1624,7 @@ import spock.lang.Unroll
                 doLast {
                     def resolvedArtifacts = project.configurations.compileClasspath.resolvedConfiguration.resolvedArtifacts.collect { it.toString() }
                     task.dependenciesAsStrings = resolvedArtifacts
-
+                    
                     println("Resolved artifacts: \${resolvedArtifacts.join(', ')}")
                 }
             }
@@ -535,8 +1674,8 @@ import spock.lang.Unroll
             }
             """.stripIndent()
 
-        addSubproject('sub1', subProjectBuildFileContent)
-        addSubproject('sub2', subProjectBuildFileContent)
+        addSubproject("sub1", subProjectBuildFileContent)
+        addSubproject("sub2", subProjectBuildFileContent)
 
         writeHelloWorld(new File(projectDir, 'sub1'))
         writeHelloWorld(new File(projectDir, 'sub2'))
@@ -548,30 +1687,30 @@ import spock.lang.Unroll
         setupSingleProject()
         settingsFile << "\nincludeBuild('included-project')"
 
-        def includedProjectDir = new File(projectDir, 'included-project')
+        def includedProjectDir = new File(projectDir, "included-project")
         includedProjectDir.mkdirs()
-        def includedProjectBuildFile = new File(includedProjectDir, 'build.gradle')
+        def includedProjectBuildFile = new File(includedProjectDir, "build.gradle")
         includedProjectBuildFile.createNewFile()
         includedProjectBuildFile.text = """
             plugins {
                 id 'java'
             }
             """.stripIndent()
-        def includedProjectSettingsFile = new File(includedProjectDir, 'settings.gradle')
+        def includedProjectSettingsFile = new File(includedProjectDir, "settings.gradle")
         includedProjectSettingsFile.createNewFile()
         includedProjectSettingsFile.text = """
             rootProject.name = 'included-project'
-
+            
             include "sub1"
             include "sub2"
             """.stripIndent()
-        def includedSub1Dir = new File(includedProjectDir, 'sub1')
+        def includedSub1Dir = new File(includedProjectDir, "sub1")
         includedSub1Dir.mkdirs()
-        def includedSub1BuildFiles = new File(includedSub1Dir, 'build.gradle')
+        def includedSub1BuildFiles = new File(includedSub1Dir, "build.gradle")
         includedSub1BuildFiles.text = buildFile.text
-        def includedSub2Dir = new File(includedProjectDir, 'sub2')
+        def includedSub2Dir = new File(includedProjectDir, "sub2")
         includedSub2Dir.mkdirs()
-        def includedSub2BuildFiles = new File(includedSub2Dir, 'build.gradle')
+        def includedSub2BuildFiles = new File(includedSub2Dir, "build.gradle")
         includedSub2BuildFiles.text = buildFile.text
     }
 
@@ -637,7 +1776,7 @@ import spock.lang.Unroll
                     resolutionRules files('$rulesJsonFile')
                 }
             }
-
+      
             """.stripIndent()
 
         def subProject1BuildFileContent = """
@@ -656,13 +1795,13 @@ import spock.lang.Unroll
             }
             """.stripIndent()
 
-        addSubproject('sub1', subProject1BuildFileContent)
-        addSubproject('sub2', subProject2BuildFileContent)
+        addSubproject("sub1", subProject1BuildFileContent)
+        addSubproject("sub2", subProject2BuildFileContent)
 
         def dependencyLock = new File(projectDir, 'dependencies.lock')
         def dependencyLockSubproject1 = new File(projectDir, 'sub1/dependencies.lock')
         def dependencyLockSubproject2 = new File(projectDir, 'sub2/dependencies.lock')
-        dependencyLock << '{ }'
+        dependencyLock << "{ }"
         dependencyLockSubproject1 << dependencyLockFileContents
 
         def dependencyLockFileContentsSubproject2 = '''\
@@ -817,5 +1956,4 @@ import spock.lang.Unroll
         !secondRun.output.contains('Reusing configuration cache') &&
             !secondRun.output.contains('Configuration cache entry reused')
     }
-
 }

--- a/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
+++ b/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
@@ -1903,4 +1903,35 @@ class DependencyResolutionVerifierTest extends BaseIntegrationTestKitSpec {
         '''.stripIndent()
         [mavenrepo, rulesJsonFile, dependencyLockFileContents]
     }
+
+    def 'verifyDependencyResolution task is registered before afterEvaluate runs'() {
+        given:
+        // Use init-script classpath injection so `apply plugin:` works outside the plugins {} block.
+        // This lets us register an afterEvaluate callback before the plugin is applied, exercising
+        // the constraint that registerVerificationTask() must be called eagerly (not deferred).
+        definePluginOutsideOfPluginBlock = true
+
+        // Register an afterEvaluate callback BEFORE applying the lock plugin.
+        // Gradle fires afterEvaluate callbacks in registration order, so this fires before
+        // the lock plugin's own afterEvaluate. If registerVerificationTask() is called
+        // eagerly (synchronously in apply()), the task exists here; if it was deferred
+        // inside afterEvaluate, it would not.
+        buildFile << """\
+            afterEvaluate {
+                def t = tasks.findByName('verifyDependencyResolution')
+                if (t == null) {
+                    throw new IllegalStateException(
+                        'verifyDependencyResolution was not registered before afterEvaluate ran')
+                }
+            }
+            apply plugin: 'com.netflix.nebula.dependency-lock'
+        """.stripIndent()
+
+        when:
+        def result = runTasks('help')
+
+        then:
+        !result.output.contains('verifyDependencyResolution was not registered')
+        !result.output.contains('FAILURE')
+    }
 }

--- a/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
+++ b/src/test/groovy/nebula/plugin/dependencyverifier/DependencyResolutionVerifierTest.groovy
@@ -31,7 +31,6 @@ import static nebula.plugin.dependencyverifier.DependencyResolutionVerifierTest.
 import static nebula.plugin.dependencyverifier.DependencyResolutionVerifierTest.OutputAssertions.dependencyProjectPair
 
             import nebula.plugin.dependencyverifier.DependencyResolutionVerifierExtension
-            import nebula.plugin.dependencyverifier.DependencyResolutionVerifierExtension
 import nebula.plugin.BaseIntegrationTestKitSpec
 import nebula.plugin.VerifierOutputAssertionsBase
 import nebula.test.dependencies.DependencyGraphBuilder
@@ -795,6 +794,28 @@ import spock.lang.Unroll
         then:
         !result.output.contains('verifyDependencyResolution was not registered')
         !result.output.contains('FAILURE')
+    }
+
+    def 'coreAlignmentEnabled system property change invalidates configuration cache entry'() {
+        given:
+        setupSingleProject()
+        def gradleProps = new File(projectDir, 'gradle.properties')
+
+        when: 'first run with system property false'
+        gradleProps.text = 'org.gradle.configuration-cache=true\norg.gradle.warning.mode=fail\nsystemProp.nebula.features.coreAlignmentSupport=false'
+        def firstRun = runTasks('help')
+
+        then: 'configuration cache entry is stored'
+        firstRun.output.contains('Configuration cache entry stored') ||
+            firstRun.output.contains('configuration cache')
+
+        when: 'second run with system property changed to true'
+        gradleProps.text = 'org.gradle.configuration-cache=true\norg.gradle.warning.mode=fail\nsystemProp.nebula.features.coreAlignmentSupport=true'
+        def secondRun = runTasks('help')
+
+        then: 'configuration cache entry is NOT reused — system property change must invalidate cache'
+        !secondRun.output.contains('Reusing configuration cache') &&
+            !secondRun.output.contains('Configuration cache entry reused')
     }
 
 }


### PR DESCRIPTION
# Summary

The "modernize project" commits migrated all extension properties to Gradle's Property API for configuration cache (CC) compatibility — but it broke the existing public API. Every property getter changed return type from `String`/`Boolean`/`Set<String>` to `Property<T>`, breaking downstream build scripts and plugins that used Groovy DSL assignment (`extension.lockFile = 'custom.lock'`) or read the value as a plain type.

This PR restores the old public API without removing CC safety, and fixes two correctness bugs found during a multi-lens red-team review.

# What changed

Backward-compatible bridge pattern (both extensions)

Every property now follows a two-name convention:
- `getFooProperty()` — the Gradle-managed `Property<T>` / `SetProperty<T>`, used by internal plugin code for CC-safe lazy task wiring
- `getFoo()` / `setFoo()` — concrete methods returning plain `String` / `Boolean` / `Set<String>`, restoring the pre-modernization public API for downstream build scripts

`Set<String>` bridge getters return a new `LinkedHashSet<>()` defensive copy so callers can mutate the result without `UnsupportedOperationException` and without accidentally mutating extension state.

## dependencyFilter deprecation

Closure `dependencyFilter` is not configuration-cache serializable. It is now marked `@Deprecated @Internal` and `setDependencyFilter()` logs a warning on first use explaining the CC incompatibility.
`@Internal` prevents it from affecting task input fingerprints.

# Bug fixes

- parseLockFile returned an empty map when `Moshi.fromJson()` returned null (triggered by a lock file whose entire content is the JSON literal null). This silently skipped all lock enforcement. Now throws GradleException — same behaviour as malformed JSON.
- DependencyResolutionVerifier used `System.getProperty("nebula.features.coreAlignmentSupport")` at configuration time, baking the value into the CC entry and ignoring changes on subsequent builds. Replaced with `project.providers.systemProperty(...)` so the property is tracked as a CC input and properly invalidates the cache when changed.
- Malformed `dependencyLock.override` coordinates (fewer than 3 colon-separated segments) previously stored null as the version, causing a `NullPointerException` during CC serialization. Now validated and skipped with a `WARN` log.
- `conf.onResolve` (`nebula-interop extension`) replaced with the standard
`conf.incoming.beforeResolve` callback.
- `verifyDependencyResolution` task registered eagerly before `afterEvaluate` so downstream plugins that inspect the task container during configuration don't hit an immutable-container error.
