### PR TITLE
Handle project locks without previous versions

### DIFF
--- a/src/main/kotlin/nebula/plugin/dependencylock/diff/PathAwareDiffReportGenerator.kt
+++ b/src/main/kotlin/nebula/plugin/dependencylock/diff/PathAwareDiffReportGenerator.kt
@@ -161,7 +161,9 @@ class PathAwareDiffReportGenerator : DiffReportGenerator {
                         "type" to if (diff.isNew) "NEW" else "UPDATED"
                 )
                 if (diff.isUpdated) {
-                    change["previousVersion"] = dependencyPathElement.getPreviousVersion()
+                    dependencyPathElement.getPreviousVersion()?.let {
+                        change["previousVersion"] = it
+                    }
                 }
                 result["change"] = change
             }
@@ -185,9 +187,8 @@ class PathAwareDiffReportGenerator : DiffReportGenerator {
             return dependencyDiff != null
         }
 
-        fun getPreviousVersion(): String {
-            return dependencyDiff?.diff?.values?.first()?.oldVersion
-                    ?: throw IllegalStateException("Dependency wasn't updated so it doesn't have previous version")
+        fun getPreviousVersion(): String? {
+            return dependencyDiff?.diff?.values?.firstOrNull()?.oldVersion
         }
 
 

--- a/src/test/groovy/nebula/plugin/dependencylock/PathAwareDependencyDiffSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/PathAwareDependencyDiffSpec.groovy
@@ -939,6 +939,56 @@ class PathAwareDependencyDiffSpec extends BaseIntegrationTestKitSpec {
         foo.children[0].change.previousVersion == "1.0.0"
     }
 
+    def 'diff lock with paths handles local submodule whose existing lock has no version'() {
+        new File("${projectDir}/gradle.properties").text = "systemProp.nebula.features.pathAwareDependencyDiff=true"
+        buildFile << """\
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            allprojects {
+                apply plugin: 'java-library'
+                apply plugin: 'com.netflix.nebula.dependency-lock'
+
+                group = 'test'
+            }
+        """.stripIndent()
+
+        addSubproject("common", "")
+        addSubproject("app", """
+            dependencies {
+                implementation project(':common')
+            }
+        """)
+
+        def existingLock = new File(projectDir, 'app/dependencies.lock')
+        existingLock << LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly('''\
+                    "test:common": {
+                        "project": true
+                    }
+                '''.stripIndent())
+
+        def updatedLock = new File(projectDir, 'app/build/dependencies.lock')
+        updatedLock.parentFile.mkdirs()
+        updatedLock << LockGenerator.duplicateIntoConfigsWhenUsingImplementationConfigurationOnly('''\
+                    "test:common": {
+                        "locked": "1.0.0"
+                    }
+                '''.stripIndent())
+
+        when:
+        def result = runTasks(':app:diffLock')
+
+        then:
+        result.output.contains('BUILD SUCCESSFUL')
+        def lockdiff = new JsonSlurper().parse(new File(projectDir, 'app/build/dependency-lock/lockdiff.json'))
+        def directDependencies = lockdiff[0]["differentPaths"]
+        def common = directDependencies.find { it.dependency == "test:common" }
+        common.submodule == true
+        common.change.type == "UPDATED"
+        common.change.previousVersion == null
+    }
+
     def 'diff lock with new submodule dependency'() {
         new File("${projectDir}/gradle.properties").text = "systemProp.nebula.features.pathAwareDependencyDiff=true"
         buildFile << """\


### PR DESCRIPTION
## Summary
- Avoid failing path-aware lock diffs when a local project lock has no prior version.
- Omit `previousVersion` when the prior lock used the `project` marker.
- Add an integration regression test for the `project: true` to `locked` transition.

## Testing
- `./gradlew test --tests nebula.plugin.dependencylock.PathAwareDependencyDiffSpec -x verifyDependencyResolution --stacktrace`
