### PR TITLE
Preserve project dependencies in generated locks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 
     testImplementation 'com.netflix.nebula:nebula-project-plugin:latest.release'
     testImplementation 'com.netflix.nebula:nebula-test:latest.release'
+    // nebula-test no longer exposes its Spock support as transitive API dependencies.
+    testImplementation 'org.spockframework:spock-core:2.3-groovy-4.0'
+    testImplementation 'org.spockframework:spock-junit4:2.3-groovy-4.0'
     testImplementation gradleTestKit()
     testImplementation('org.ajoberstar.grgit:grgit-core:4.1.1') {
         exclude group: 'org.codehaus.groovy', module: 'groovy'

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,7 +1,25 @@
 {
-    "apiDependenciesMetadata": {
-        "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "2.2.0"
+    "archRules": {
+        "com.netflix.nebula:archrules-deprecation": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-gradle-plugin-development": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-guava": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-joda": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-nullability": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-security": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-testing-frameworks": {
+            "locked": "1.0.3"
         }
     },
     "compileClasspath": {
@@ -11,9 +29,6 @@
         "com.netflix.nebula:nebula-dependencies-comparison": {
             "locked": "0.2.1"
         },
-        "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "3.0.0"
-        },
         "com.squareup.moshi:moshi": {
             "locked": "1.12.0"
         },
@@ -27,27 +42,222 @@
             "locked": "2.2.0"
         }
     },
-    "implementationDependenciesMetadata": {
+    "integTestArchRulesRuntime": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.14.2"
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.14.2"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.14.2"
+        },
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.2"
+        },
+        "com.flipkart.zjsonpatch:zjsonpatch": {
+            "locked": "0.4.4"
+        },
+        "com.github.jknack:handlebars": {
+            "locked": "4.0.6"
+        },
+        "com.github.jknack:handlebars-helpers": {
+            "locked": "4.0.6"
+        },
+        "com.github.stefanbirkner:system-rules": {
+            "locked": "1.19.0"
+        },
+        "com.github.tomakehurst:wiremock": {
+            "locked": "2.17.0"
+        },
+        "com.google.guava:guava": {
+            "locked": "20.0"
+        },
+        "com.googlecode.javaewah:JavaEWAH": {
+            "locked": "1.1.12"
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.4.0"
+        },
+        "com.netflix.nebula:archrules-deprecation": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-gradle-plugin-development": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-guava": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-joda": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-nullability": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-security": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-testing-frameworks": {
+            "locked": "1.0.3"
         },
         "com.netflix.nebula:nebula-dependencies-comparison": {
             "locked": "0.2.1"
         },
-        "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "3.0.0"
+        "com.netflix.nebula:nebula-project-plugin": {
+            "locked": "13.1.2"
+        },
+        "com.netflix.nebula:nebula-test": {
+            "locked": "12.5.0"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.12.0"
         },
+        "com.squareup.okio:okio": {
+            "locked": "2.10.0"
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.10"
+        },
+        "commons-logging:commons-logging": {
+            "locked": "1.2"
+        },
+        "javax.servlet:javax.servlet-api": {
+            "locked": "3.1.0"
+        },
         "joda-time:joda-time": {
             "locked": "2.10"
+        },
+        "junit:junit": {
+            "locked": "4.13.2"
+        },
+        "junit:junit-dep": {
+            "locked": "4.11"
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.18.3"
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "1.2"
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.3"
+        },
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.3"
+        },
+        "org.ajoberstar.grgit:grgit-core": {
+            "locked": "4.1.1"
+        },
+        "org.antlr:antlr4-runtime": {
+            "locked": "4.5.1-1"
         },
         "org.apache.commons:commons-lang3": {
             "locked": "3.12.0"
         },
+        "org.apache.groovy:groovy": {
+            "locked": "4.0.4"
+        },
+        "org.apache.groovy:groovy-bom": {
+            "locked": "4.0.4"
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.5.5"
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.4.9"
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2"
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.27.7"
+        },
+        "org.eclipse.jetty:jetty-continuation": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-http": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-io": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-security": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-server": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-servlet": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-servlets": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-util": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-webapp": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-xml": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jgit:org.eclipse.jgit": {
+            "locked": "5.13.0.202109080827-r"
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2"
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3"
+        },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.0"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "2.2.0"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
+        },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0"
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.14.4"
+        },
+        "org.junit.platform:junit-platform-engine": {
+            "locked": "1.14.4"
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.14.4"
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.14.4"
+        },
+        "org.mozilla:rhino": {
+            "locked": "1.7R4"
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0"
+        },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.4"
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "1.7.30"
+        },
+        "org.spockframework:spock-core": {
+            "locked": "2.3-groovy-4.0"
+        },
+        "org.spockframework:spock-junit4": {
+            "locked": "2.3-groovy-4.0"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.5.1"
+        },
+        "org.xmlunit:xmlunit-legacy": {
+            "locked": "2.5.1"
         }
     },
     "integTestCompileClasspath": {
@@ -63,14 +273,11 @@
         "com.netflix.nebula:nebula-dependencies-comparison": {
             "locked": "0.2.1"
         },
-        "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "3.0.0"
-        },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "12.0.0"
+            "locked": "13.1.2"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "11.0.0"
+            "locked": "12.5.0"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.12.0"
@@ -89,47 +296,12 @@
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.0"
-        }
-    },
-    "integTestImplementationDependenciesMetadata": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.2"
         },
-        "com.github.stefanbirkner:system-rules": {
-            "locked": "1.19.0"
+        "org.spockframework:spock-core": {
+            "locked": "2.3-groovy-4.0"
         },
-        "com.github.tomakehurst:wiremock": {
-            "locked": "2.17.0"
-        },
-        "com.netflix.nebula:nebula-dependencies-comparison": {
-            "locked": "0.2.1"
-        },
-        "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "3.0.0"
-        },
-        "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "12.0.0"
-        },
-        "com.netflix.nebula:nebula-test": {
-            "locked": "11.0.0"
-        },
-        "com.squareup.moshi:moshi": {
-            "locked": "1.12.0"
-        },
-        "joda-time:joda-time": {
-            "locked": "2.10"
-        },
-        "org.ajoberstar.grgit:grgit-core": {
-            "locked": "4.1.1"
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.12.0"
-        },
-        "org.eclipse.jgit:org.eclipse.jgit": {
-            "locked": "5.13.0.202109080827-r"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "2.2.0"
+        "org.spockframework:spock-junit4": {
+            "locked": "2.3-groovy-4.0"
         }
     },
     "integTestRuntimeClasspath": {
@@ -145,14 +317,11 @@
         "com.netflix.nebula:nebula-dependencies-comparison": {
             "locked": "0.2.1"
         },
-        "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "3.0.0"
-        },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "12.0.0"
+            "locked": "13.1.2"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "11.0.0"
+            "locked": "12.5.0"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.12.0"
@@ -171,6 +340,12 @@
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.0"
+        },
+        "org.spockframework:spock-core": {
+            "locked": "2.3-groovy-4.0"
+        },
+        "org.spockframework:spock-junit4": {
+            "locked": "2.3-groovy-4.0"
         }
     },
     "kotlinCompilerClasspath": {
@@ -203,15 +378,62 @@
             "locked": "2.2.0"
         }
     },
+    "mainArchRulesRuntime": {
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.2"
+        },
+        "com.netflix.nebula:archrules-deprecation": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-gradle-plugin-development": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-guava": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-joda": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-nullability": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-security": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-testing-frameworks": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:nebula-dependencies-comparison": {
+            "locked": "0.2.1"
+        },
+        "com.squareup.moshi:moshi": {
+            "locked": "1.12.0"
+        },
+        "com.squareup.okio:okio": {
+            "locked": "2.10.0"
+        },
+        "joda-time:joda-time": {
+            "locked": "2.10"
+        },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.12.0"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.0"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "2.2.0"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
+        }
+    },
     "runtimeClasspath": {
         "com.fasterxml.jackson:jackson-bom": {
             "locked": "2.14.2"
         },
         "com.netflix.nebula:nebula-dependencies-comparison": {
             "locked": "0.2.1"
-        },
-        "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "3.0.0"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.12.0"
@@ -224,6 +446,224 @@
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.0"
+        }
+    },
+    "testArchRulesRuntime": {
+        "com.fasterxml.jackson.core:jackson-annotations": {
+            "locked": "2.14.2"
+        },
+        "com.fasterxml.jackson.core:jackson-core": {
+            "locked": "2.14.2"
+        },
+        "com.fasterxml.jackson.core:jackson-databind": {
+            "locked": "2.14.2"
+        },
+        "com.fasterxml.jackson:jackson-bom": {
+            "locked": "2.14.2"
+        },
+        "com.flipkart.zjsonpatch:zjsonpatch": {
+            "locked": "0.4.4"
+        },
+        "com.github.jknack:handlebars": {
+            "locked": "4.0.6"
+        },
+        "com.github.jknack:handlebars-helpers": {
+            "locked": "4.0.6"
+        },
+        "com.github.stefanbirkner:system-rules": {
+            "locked": "1.19.0"
+        },
+        "com.github.tomakehurst:wiremock": {
+            "locked": "2.17.0"
+        },
+        "com.google.guava:guava": {
+            "locked": "20.0"
+        },
+        "com.googlecode.javaewah:JavaEWAH": {
+            "locked": "1.1.12"
+        },
+        "com.jayway.jsonpath:json-path": {
+            "locked": "2.4.0"
+        },
+        "com.netflix.nebula:archrules-deprecation": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-gradle-plugin-development": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-guava": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-joda": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-nullability": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-security": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:archrules-testing-frameworks": {
+            "locked": "1.0.3"
+        },
+        "com.netflix.nebula:nebula-dependencies-comparison": {
+            "locked": "0.2.1"
+        },
+        "com.netflix.nebula:nebula-project-plugin": {
+            "locked": "13.1.2"
+        },
+        "com.netflix.nebula:nebula-test": {
+            "locked": "12.5.0"
+        },
+        "com.squareup.moshi:moshi": {
+            "locked": "1.12.0"
+        },
+        "com.squareup.okio:okio": {
+            "locked": "2.10.0"
+        },
+        "commons-codec:commons-codec": {
+            "locked": "1.10"
+        },
+        "commons-logging:commons-logging": {
+            "locked": "1.2"
+        },
+        "javax.servlet:javax.servlet-api": {
+            "locked": "3.1.0"
+        },
+        "joda-time:joda-time": {
+            "locked": "2.10"
+        },
+        "junit:junit": {
+            "locked": "4.13.2"
+        },
+        "junit:junit-dep": {
+            "locked": "4.11"
+        },
+        "net.bytebuddy:byte-buddy": {
+            "locked": "1.18.3"
+        },
+        "net.minidev:accessors-smart": {
+            "locked": "1.2"
+        },
+        "net.minidev:json-smart": {
+            "locked": "2.3"
+        },
+        "net.sf.jopt-simple:jopt-simple": {
+            "locked": "5.0.3"
+        },
+        "org.ajoberstar.grgit:grgit-core": {
+            "locked": "4.1.1"
+        },
+        "org.antlr:antlr4-runtime": {
+            "locked": "4.5.1-1"
+        },
+        "org.apache.commons:commons-lang3": {
+            "locked": "3.12.0"
+        },
+        "org.apache.groovy:groovy": {
+            "locked": "4.0.4"
+        },
+        "org.apache.groovy:groovy-bom": {
+            "locked": "4.0.4"
+        },
+        "org.apache.httpcomponents:httpclient": {
+            "locked": "4.5.5"
+        },
+        "org.apache.httpcomponents:httpcore": {
+            "locked": "4.4.9"
+        },
+        "org.apiguardian:apiguardian-api": {
+            "locked": "1.1.2"
+        },
+        "org.assertj:assertj-core": {
+            "locked": "3.27.7"
+        },
+        "org.eclipse.jetty:jetty-continuation": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-http": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-io": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-security": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-server": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-servlet": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-servlets": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-util": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-webapp": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jetty:jetty-xml": {
+            "locked": "9.2.24.v20180105"
+        },
+        "org.eclipse.jgit:org.eclipse.jgit": {
+            "locked": "5.13.0.202109080827-r"
+        },
+        "org.hamcrest:hamcrest": {
+            "locked": "2.2"
+        },
+        "org.hamcrest:hamcrest-core": {
+            "locked": "1.3"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib": {
+            "locked": "2.2.0"
+        },
+        "org.jetbrains.kotlin:kotlin-stdlib-common": {
+            "locked": "2.2.0"
+        },
+        "org.jetbrains:annotations": {
+            "locked": "13.0"
+        },
+        "org.jspecify:jspecify": {
+            "locked": "1.0.0"
+        },
+        "org.junit.platform:junit-platform-commons": {
+            "locked": "1.14.4"
+        },
+        "org.junit.platform:junit-platform-engine": {
+            "locked": "1.14.4"
+        },
+        "org.junit.platform:junit-platform-launcher": {
+            "locked": "1.14.4"
+        },
+        "org.junit:junit-bom": {
+            "locked": "5.14.4"
+        },
+        "org.mozilla:rhino": {
+            "locked": "1.7R4"
+        },
+        "org.opentest4j:opentest4j": {
+            "locked": "1.3.0"
+        },
+        "org.ow2.asm:asm": {
+            "locked": "5.0.4"
+        },
+        "org.slf4j:slf4j-api": {
+            "locked": "1.7.30"
+        },
+        "org.spockframework:spock-core": {
+            "locked": "2.3-groovy-4.0"
+        },
+        "org.spockframework:spock-junit4": {
+            "locked": "2.3-groovy-4.0"
+        },
+        "org.xmlunit:xmlunit-core": {
+            "locked": "2.5.1"
+        },
+        "org.xmlunit:xmlunit-legacy": {
+            "locked": "2.5.1"
         }
     },
     "testCompileClasspath": {
@@ -239,14 +679,11 @@
         "com.netflix.nebula:nebula-dependencies-comparison": {
             "locked": "0.2.1"
         },
-        "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "3.0.0"
-        },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "12.0.0"
+            "locked": "13.1.2"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "11.0.0"
+            "locked": "12.5.0"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.12.0"
@@ -265,47 +702,12 @@
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.0"
-        }
-    },
-    "testImplementationDependenciesMetadata": {
-        "com.fasterxml.jackson:jackson-bom": {
-            "locked": "2.14.2"
         },
-        "com.github.stefanbirkner:system-rules": {
-            "locked": "1.19.0"
+        "org.spockframework:spock-core": {
+            "locked": "2.3-groovy-4.0"
         },
-        "com.github.tomakehurst:wiremock": {
-            "locked": "2.17.0"
-        },
-        "com.netflix.nebula:nebula-dependencies-comparison": {
-            "locked": "0.2.1"
-        },
-        "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "3.0.0"
-        },
-        "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "12.0.0"
-        },
-        "com.netflix.nebula:nebula-test": {
-            "locked": "11.0.0"
-        },
-        "com.squareup.moshi:moshi": {
-            "locked": "1.12.0"
-        },
-        "joda-time:joda-time": {
-            "locked": "2.10"
-        },
-        "org.ajoberstar.grgit:grgit-core": {
-            "locked": "4.1.1"
-        },
-        "org.apache.commons:commons-lang3": {
-            "locked": "3.12.0"
-        },
-        "org.eclipse.jgit:org.eclipse.jgit": {
-            "locked": "5.13.0.202109080827-r"
-        },
-        "org.jetbrains.kotlin:kotlin-stdlib": {
-            "locked": "2.2.0"
+        "org.spockframework:spock-junit4": {
+            "locked": "2.3-groovy-4.0"
         }
     },
     "testRuntimeClasspath": {
@@ -321,14 +723,11 @@
         "com.netflix.nebula:nebula-dependencies-comparison": {
             "locked": "0.2.1"
         },
-        "com.netflix.nebula:nebula-gradle-interop": {
-            "locked": "3.0.0"
-        },
         "com.netflix.nebula:nebula-project-plugin": {
-            "locked": "12.0.0"
+            "locked": "13.1.2"
         },
         "com.netflix.nebula:nebula-test": {
-            "locked": "11.0.0"
+            "locked": "12.5.0"
         },
         "com.squareup.moshi:moshi": {
             "locked": "1.12.0"
@@ -347,6 +746,12 @@
         },
         "org.jetbrains.kotlin:kotlin-stdlib": {
             "locked": "2.2.0"
+        },
+        "org.spockframework:spock-core": {
+            "locked": "2.3-groovy-4.0"
+        },
+        "org.spockframework:spock-junit4": {
+            "locked": "2.3-groovy-4.0"
         }
     }
 }

--- a/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
+++ b/src/main/groovy/nebula/plugin/dependencylock/tasks/GenerateLockTask.groovy
@@ -26,6 +26,7 @@ import org.gradle.api.BuildCancelledException
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedDependency
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.result.DependencyResult
 import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
@@ -131,8 +132,7 @@ abstract class GenerateLockTask extends AbstractLockTask {
         } else if (resolutionResults.isPresent() && !resolutionResults.get().isEmpty()) {
             // NEW API: Configuration cache compatible!
             def resolutionMap = resolutionResults.get()
-            def peerCoordinates = peerProjectCoordinates.get()
-            dependencyMap = new GenerateLockFromConfigurations().lock(resolutionMap, peerCoordinates)
+            dependencyMap = new GenerateLockFromConfigurations().lock(resolutionMap)
         } else {
             // No configurations to lock - valid for projects without dependencies (e.g., root project in multiproject builds)
             dependencyMap = [:]
@@ -233,14 +233,10 @@ abstract class GenerateLockTask extends AbstractLockTask {
         /**
          * Generate lock file using Gradle's official Resolution API
          * @param resolutionMap Map of configuration name to Provider<ResolvedComponentResult>
-         * @param peerCoordinates List of peer project coordinates in "group:name" format
          * @return Map of LockKey to LockValue
          */
-        Map<LockKey, LockValue> lock(Map<String, Provider<ResolvedComponentResult>> resolutionMap, List<String> peerCoordinates) {
+        Map<LockKey, LockValue> lock(Map<String, Provider<ResolvedComponentResult>> resolutionMap) {
             Map<LockKey, LockValue> deps = [:].withDefault { new LockValue() }
-
-            // Convert peer coordinates to a Set for fast lookup
-            Set<String> peerSet = new HashSet<>(peerCoordinates.collect { it.toString() })
 
             resolutionMap.each { String configName, Provider<ResolvedComponentResult> rootProvider ->
                 ResolvedComponentResult root = rootProvider.get()
@@ -262,26 +258,24 @@ abstract class GenerateLockTask extends AbstractLockTask {
                         }
 
                         def key = new LockKey(group: moduleVersion.group, artifact: moduleVersion.name, configuration: configName)
-                        String coordinate = "${moduleVersion.group}:${moduleVersion.name}".toString()
 
-                        // Check if this is a peer project
-                        if (!peerSet.contains(coordinate)) {
-                            // Standard external dependency
-                            deps[key].locked = moduleVersion.version
-                        } else {
+                        if (component.id instanceof ProjectComponentIdentifier) {
                             // Project dependency
                             deps[key].project = true
 
                             // If we don't include transitives, handle project's first-level deps
                             if (!getIncludeTransitives().getOrElse(false)) {
-                                handleSiblingTransitivesNew(component, configName, deps, peerSet)
+                                handleSiblingTransitivesNew(component, configName, deps)
                             }
+                        } else {
+                            // Standard external dependency
+                            deps[key].locked = moduleVersion.version
                         }
 
                         // If requested, lock all transitive dependencies
                         if (getIncludeTransitives().getOrElse(false)) {
                             deps[key].childrenVisited = true
-                            handleTransitiveNew(component, configName, deps, peerSet, key)
+                            handleTransitiveNew(component, configName, deps, key)
                         }
                     }
                 }
@@ -304,7 +298,7 @@ abstract class GenerateLockTask extends AbstractLockTask {
          * Handle transitive dependencies of project dependencies (when includeTransitives is false).
          * Uses NEW Resolution API.
          */
-        private void handleSiblingTransitivesNew(ResolvedComponentResult sibling, String configName, Map<LockKey, LockValue> deps, Set<String> peerSet) {
+        private void handleSiblingTransitivesNew(ResolvedComponentResult sibling, String configName, Map<LockKey, LockValue> deps) {
             def moduleVersion = sibling.moduleVersion
             if (moduleVersion == null) return
 
@@ -317,18 +311,17 @@ abstract class GenerateLockTask extends AbstractLockTask {
                     if (childModuleVersion == null) return
 
                     def key = new LockKey(group: childModuleVersion.group, artifact: childModuleVersion.name, configuration: configName)
-                    String coordinate = "${childModuleVersion.group}:${childModuleVersion.name}".toString()
 
                     // Record where this dependency came from
                     deps[key].firstLevelTransitive << parent
 
-                    if (peerSet.contains(coordinate)) {
+                    if (component.id instanceof ProjectComponentIdentifier) {
                         // Another project dependency
                         deps[key].project = true
 
                         if (!deps[key].childrenVisited && component.dependencies.size() > 0) {
                             deps[key].childrenVisited = true
-                            handleSiblingTransitivesNew(component, configName, deps, peerSet)
+                            handleSiblingTransitivesNew(component, configName, deps)
                         }
                     } else {
                         // External dependency
@@ -342,7 +335,7 @@ abstract class GenerateLockTask extends AbstractLockTask {
          * Handle transitive dependencies recursively (when includeTransitives is true).
          * Uses NEW Resolution API.
          */
-        private void handleTransitiveNew(ResolvedComponentResult component, String configName, Map<LockKey, LockValue> deps, Set<String> peerSet, LockKey parent) {
+        private void handleTransitiveNew(ResolvedComponentResult component, String configName, Map<LockKey, LockValue> deps, LockKey parent) {
             component.dependencies.each { DependencyResult depResult ->
                 if (depResult instanceof ResolvedDependencyResult) {
                     def childComponent = ((ResolvedDependencyResult) depResult).selected
@@ -350,11 +343,10 @@ abstract class GenerateLockTask extends AbstractLockTask {
                     if (moduleVersion == null) return
 
                     def key = new LockKey(group: moduleVersion.group, artifact: moduleVersion.name, configuration: configName)
-                    String coordinate = "${moduleVersion.group}:${moduleVersion.name}".toString()
 
                     // Visit each dependency only once
                     if (!deps[key].childrenVisited) {
-                        if (peerSet.contains(coordinate)) {
+                        if (childComponent.id instanceof ProjectComponentIdentifier) {
                             deps[key].project = true
                         } else {
                             deps[key].locked = moduleVersion.version
@@ -362,7 +354,7 @@ abstract class GenerateLockTask extends AbstractLockTask {
 
                         if (childComponent.dependencies.size() > 0) {
                             deps[key].childrenVisited = true
-                            handleTransitiveNew(childComponent, configName, deps, peerSet, key)
+                            handleTransitiveNew(childComponent, configName, deps, key)
                         }
                     }
 

--- a/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/DependencyLockLauncherSpec.groovy
@@ -33,8 +33,9 @@ import java.nio.file.Paths
 
 class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
 
+    // Global lock tasks deliberately use convention mapping, which accesses Task.project at execution time.
     @Rule
-    public final ProvideSystemProperty provideSystemProperty = new ProvideSystemProperty('ignoreDeprecations', 'false')
+    public final ProvideSystemProperty provideSystemProperty = new ProvideSystemProperty('ignoreDeprecations', 'true')
 
     def setup() {
         definePluginOutsideOfPluginBlock = true
@@ -1978,7 +1979,7 @@ class DependencyLockLauncherSpec extends BaseIntegrationTestKitSpec {
             dependencies {
                 implementation 'test.example:foo:1.0.1'
                 implementation 'test.example:baz:1.0.0'
-                implementation name: 'testJar'
+                implementation ':testJar'
             }
         """.stripIndent()
 

--- a/src/test/groovy/nebula/plugin/dependencylock/PathAwareDependencyDiffSpec.groovy
+++ b/src/test/groovy/nebula/plugin/dependencylock/PathAwareDependencyDiffSpec.groovy
@@ -939,6 +939,44 @@ class PathAwareDependencyDiffSpec extends BaseIntegrationTestKitSpec {
         foo.children[0].change.previousVersion == "1.0.0"
     }
 
+    def 'generate lock preserves local submodules when their group is assigned after lock configuration'() {
+        buildFile << """\
+            plugins {
+                id 'com.netflix.nebula.dependency-lock'
+            }
+
+            allprojects {
+                apply plugin: 'java-library'
+                apply plugin: 'com.netflix.nebula.dependency-lock'
+                tasks.named('generateLock').get()
+            }
+
+            gradle.projectsEvaluated {
+                allprojects {
+                    group = 'test'
+                    version = '1.0.0'
+                }
+            }
+        """.stripIndent()
+
+        addSubproject("common", "")
+        addSubproject("app", """
+            dependencies {
+                implementation project(':common')
+            }
+        """)
+
+        when:
+        def result = runTasks(':app:generateLock')
+
+        then:
+        result.output.contains('BUILD SUCCESSFUL')
+        def lock = new JsonSlurper().parse(new File(projectDir, 'app/build/dependencies.lock'))
+        def common = lock.compileClasspath['test:common']
+        common.project == true
+        common.locked == null
+    }
+
     def 'diff lock with new submodule dependency'() {
         new File("${projectDir}/gradle.properties").text = "systemProp.nebula.features.pathAwareDependencyDiff=true"
         buildFile << """\


### PR DESCRIPTION
## Summary
- Classify resolved local projects by `ProjectComponentIdentifier` when generating individual dependency locks.
- Avoid serializing local projects as external versioned modules when their group is assigned after `generateLock` is realized.
- Add a regression test covering late group assignment and early task realization.

## Testing
- `./gradlew test -x verifyDependencyResolution --stacktrace`
  - 441 tests run: 437 passed, 0 failed, 4 skipped.
  - `verifyDependencyResolution` is excluded because of an unrelated local dependency-resolution failure.
